### PR TITLE
Add dedicated Lead Detail Page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import Contacts from './pages/app/Contacts/Contacts';
 import AddContact from './pages/app/Contacts/AddContact';
 import ContactDetail from './pages/app/Contacts/ContactDetails';
 import Leads from './pages/app/Leads/Leads';
+import LeadDetail from './pages/app/Leads/LeadDetails';
 import Deals from './pages/app/Deals/Deals';
 import AddDeal from './pages/app/Deals/AddDeal'
 import AddLead from './pages/app/Leads/AddLead';
@@ -88,7 +89,8 @@ function AppRoutes() {
           <Route element={<AppLayout />}>
             <Route path="/app/dashboard" element={<Dashboard />} />
             <Route path="/app/leads" element={<Leads />} />
-            <Route path="/app/addlead" element={<AddLead />} />
+            <Route path="/app/leads/addlead" element={<AddLead />} />
+            <Route path="/app/leads/:id" element={<LeadDetail />} />
             <Route path="/app/contacts" element={<Contacts />} />
             <Route path="/app/contacts/addcontact" element={<AddContact />} />
             <Route path="/app/contacts/:id" element={<ContactDetail />} />

--- a/src/pages/app/Contacts/ContactDetails.tsx
+++ b/src/pages/app/Contacts/ContactDetails.tsx
@@ -67,7 +67,6 @@ import type { RootState } from '../../../store/store';
 import { fixLeafletIcons } from '../../../utils/fixLeafletIcons';
 import { DEPARTMENTS, GENDERS, INDUSTRIES, PREFERRED_CONTACT_TIMES, SOURCES, SUFFIXES, type Gender, type PreferredTime, type Priority, type Source, type Suffix } from '../../../types/global';
 import ErrorAlert from '../../../components/Error';
-import SuccessAlert from '../../../components/Success';
 import { formatName } from '../../../utils/formatText';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 
@@ -286,7 +285,6 @@ export default function ContactDetail() {
   const [formSocials, setFormSocials] = useState<SocialsForm>({});
   const [formCareer, setFormCareer] = useState<CareerForm>({});
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [successMessage, setSuccessMessage] = useState('');
   const [newNotes, setNewNotes] = useState("");
   const [hoveredNotes, setHoveredNotes] = useState(false);
   const [isEditingNotes, setIsEditingNotes] = useState(false);
@@ -426,11 +424,6 @@ export default function ContactDetail() {
     setIsEditingCareer(true);
   };
 
-  const success = (msg: string) => {
-    setSuccessMessage(msg);
-    setTimeout(() => setSuccessMessage(''), 3000);
-  }
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormPersonal({ ...formPersonal, [e.target.name]: e.target.value });
   };
@@ -448,7 +441,6 @@ export default function ContactDetail() {
     try {
       await dispatch(updateContactPersonal({ id: contact.id, personal: formPersonal as ContactPersonal })).unwrap();
       setIsEditingPersonal(false);
-      success("Contact updated successfully")
     } catch {
       //Error in state
     }
@@ -461,8 +453,6 @@ export default function ContactDetail() {
       await dispatch(updateContactSocials({ id: contact.id, socials: formSocials as ContactSocials })).unwrap();
       setIsEditingSocials(false);
 
-      
-      success("Contact updated successfully")
     } catch {
       //Error in state
     }
@@ -474,7 +464,6 @@ export default function ContactDetail() {
     try {
       await dispatch(updateContactCareer({ id: contact.id, career: formCareer as ContactCareer })).unwrap();
       setIsEditingCareer(false);
-      success("Contact updated successfully")
     } catch {
       //Error in state
     }
@@ -550,14 +539,6 @@ export default function ContactDetail() {
 
   return (
     <Box sx={{ maxWidth: 800, mx: 'auto', pb: 4, px: { xs: 2, sm: 3, md: 0 } }}>
-
-      <Collapse in={!!successMessage} unmountOnExit>
-        <Box sx={{ my: 2, width: '100%' }}>
-          <SuccessAlert
-            message={successMessage}
-          />
-        </Box>
-      </Collapse>
 
       <Collapse in={!!error} unmountOnExit>
       {error && (

--- a/src/pages/app/Contacts/ContactDetails.tsx
+++ b/src/pages/app/Contacts/ContactDetails.tsx
@@ -343,6 +343,7 @@ export default function ContactDetail() {
 
   const handleEditSource = () => {
         setSelectedSource(contact?.source ?? "");
+        setIsUpdatingSource(true);
       };
     
     
@@ -366,6 +367,7 @@ export default function ContactDetail() {
   
     const handleEditPreferredTime = () => {
       setSelectedPreferredTime(contact?.preferred_contact_time ?? "");
+      setIsUpdatingPreferredTime(true);
     };
     
     
@@ -683,45 +685,56 @@ export default function ContactDetail() {
             </Box>
             </Typography>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1.25, justifyContent: { xs: 'center', sm: 'flex-start' } }}>
-              <Chip
-                label={contact.status}
+              <Paper
                 title="Status"
-                size='small'
+                elevation={2}
                 sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
                   px: 1,
+                  py: 0.5,
                   fontWeight: 700,
-                  fontSize: 12,
+                  fontSize: '11px',
                   cursor: 'pointer',
                   transition: 'opacity 0.15s ease',
-                  '&:hover': { opacity: 0.85 },
-                  border: contact.status === 'Contacted' ? '1px solid #7a7a7a98' : 'none',
+                  border:
+                    contact.status === 'Contacted'
+                      ? '1px solid #7a7a7a98'
+                      : 'none',
                   backgroundColor: STATUS_COLORS[contact.status],
-                  color: contact.status === 'Contacted' ? 'black' : 'white'
+                  color: contact.status === 'Contacted' ? 'black' : 'white',
+                  borderRadius: 10,
                 }}
-              />
+              >
+                {contact.status}
+              </Paper>
               {!isUpdatingSource ? (
                 <Box
                   sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative'}}
                   onMouseEnter={() => setHoveredSource(true)}
                   onMouseLeave={() => setHoveredSource(false)}
                 >
-                  <Chip
-                    label={contact?.source}
+                  <Paper
                     title="Source"
-                    size='small'
+                    elevation={2}
                     sx={{
-                      px: '4px',
-                      py: '1px',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      px: 1,
+                      py: 0.5,
                       fontSize: '11px',
                       fontWeight: 700,
-                      color: '#252525e7',
                       letterSpacing: '0.6px',
                       cursor: 'pointer',
                       borderRadius: 10,
                       opacity: hoveredSource ? 0.4 : 1,
                     }}
-                  />
-                  <IconButton onClick={() => setIsUpdatingSource(true)} title='Update Source' sx={{p:'1px', position: 'absolute'}}>
+                  >
+                    {contact?.source}
+                  </Paper>
+                  <IconButton onClick={handleEditSource} title='Update Source' sx={{p:'1px', position: 'absolute'}}>
                     <ModeEditIcon sx={{ fontSize: '15px', opacity: hoveredSource ? 1 : 0,  transition: "all 0.3s ease", transform: hoveredSource ? "translateX(0)" : "translateX(8px)",}}/>
                   </IconButton>
                 </Box>
@@ -769,23 +782,26 @@ export default function ContactDetail() {
                   onMouseEnter={() => setHoveredPreferredTime(true)}
                   onMouseLeave={() => setHoveredPreferredTime(false)}
                 >
-                  <Chip
-                    label={contact?.preferred_contact_time}
+                  <Paper
                     title="Preferred contact time"
-                    size='small'
+                    elevation={2}
                     sx={{
-                      px: '4px',
-                      py: '1px',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      px: 1,
+                      py: 0.5,
                       fontSize: '11px',
                       fontWeight: 700,
-                      color: '#252525e7',
                       letterSpacing: '0.6px',
                       cursor: 'pointer',
                       borderRadius: 10,
                       opacity: hoveredPreferredTime ? 0.4 : 1,
                     }}
-                  />
-                  <IconButton onClick={() => setIsUpdatingPreferredTime(true)} title='Update Preferred contact time' sx={{p:'1px', position: 'absolute'}}>
+                  >
+                    {contact?.preferred_contact_time}
+                  </Paper>
+                  <IconButton onClick={handleEditPreferredTime} title='Update Preferred contact time' sx={{p:'1px', position: 'absolute'}}>
                     <ModeEditIcon sx={{ fontSize: '15px', opacity: hoveredPreferredTime ? 1 : 0,  transition: "all 0.3s ease", transform: hoveredPreferredTime ? "translateX(0)" : "translateX(8px)",}}/>
                   </IconButton>
                 </Box>
@@ -1483,11 +1499,7 @@ export default function ContactDetail() {
             variant="contained"
             disableElevation
             sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2 }}
-            onClick={() => {
-              handleUpdateSource();
-              setUpdateSource(false);
-              handleEditSource()
-            }}
+            onClick={handleUpdateSource}
           >
             Yes
           </Button>
@@ -1513,11 +1525,7 @@ export default function ContactDetail() {
             variant="contained"
             disableElevation
             sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2 }}
-            onClick={() => {
-              handleUpdatePreferredTime();
-              setUpdatePreferredTime(false);
-              handleEditPreferredTime()
-            }}
+            onClick={handleUpdatePreferredTime}
           >
             Yes
           </Button>

--- a/src/pages/app/Customers/CustomerDetail.tsx
+++ b/src/pages/app/Customers/CustomerDetail.tsx
@@ -36,7 +36,6 @@ import { formatName, formatTitle } from '../../../utils/formatText';
 import type { Priority } from '../../../types/global';
 import { clearError, deleteCustomer, fetchCustomersLists, updateCustomerNotes, updateCustomerStatus } from '../../../store/customersSlice';
 import { CUSTOMER_STATUSES, type CustomerStatus } from '../../../types/customer';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { formattedDate } from '../../../utils/formatTime';
 import PaidIcon from '@mui/icons-material/Paid';
 import { formatCurrency, totalArrayValues } from '../../../utils/formatCurrency';
@@ -156,7 +155,7 @@ export default function CustomerDetail() {
             dispatch(clearError());
             navigate(-1)
           }}
-          sx={{ mt: 2, textTransform: 'none', fontWeight: 600 }}
+          sx={{ mt: 2, textTransform: 'none', fontWeight: 600, color: 'primary.main' }}
         >
           Go back
         </Button>
@@ -225,7 +224,6 @@ export default function CustomerDetail() {
 
   const handleNewNotes = async () => {
     if (!customer || !newNotes) return;
-
 
     try {
       await dispatch(
@@ -296,35 +294,29 @@ export default function CustomerDetail() {
         </Box>
       )}
 
-      <Box sx={{display: 'flex', justifyContent: 'space-between'}}>
+      <Box sx={{display: 'flex', justifyContent: 'left'}}>
         <Button 
           startIcon={<ArrowBackIcon/>}
           onClick={() => {
-            navigate(`/app/customers`);
             navigate(-1);
           } }
-          sx={{ alignSelf: 'start', textTransform: 'none', fontWeight: 600, color: 'text.secondary'}}>
+          sx={{ alignSelf: 'start', textTransform: 'none', fontWeight: 600, color: 'primary.main'}}>
           Back
-        </Button>
-        <Button 
-          endIcon={<ArrowForwardIcon/>}
-          onClick={() => {
-            navigate('/app/deals');
-            dispatch(clearError());
-          } }
-          sx={{ alignSelf: 'start', textTransform: 'none', fontWeight: 600, color: 'text.secondary'}}>
-          Deals
         </Button>
       </Box>
       <Paper
         variant="outlined"
         sx={(theme) => ({
+          pt: '10px !important',
           p: 4,
           borderRadius: 3,
           mt: 2,
           border: `1px solid ${theme.palette.mode === 'dark' ? '#3a3a3a' : '#e3e3e3'}`,
         })}
       >
+        <Box sx={{display: 'flex', justifyContent: 'center',mb: 2}}>
+          <Typography sx={{border: '1px solid #ccc', height: '100%', borderRadius: 10,px: 2, py: 0.5, fontSize: 10, fontWeight: 700, letterSpacing: '0.15em',}}>Customer</Typography>
+        </Box>
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1, width: '100%' }}>
           <Box sx={{display: 'flex', width: 100, mr: 2, flexDirection: 'column', justifyContent: 'space-between', height: 185 }}>
             <Box sx={(theme) => ({
@@ -503,7 +495,9 @@ export default function CustomerDetail() {
                       backgroundColor: `${STATUS_COLORS[customer?.status as CustomerStatus]}55`,
                     }}
                   />
-                  <IconButton onClick={() => setUpdateStatus(true)} title='Update Status' sx={{p:'1px'}}>
+                  <IconButton onClick={() => {
+                    setIsUpdatingStatus(true)
+                  }} title='Update Status' sx={{p:'1px'}}>
                     <ModeEditIcon sx={{ fontSize: '13px', opacity: hovered ? 1 : 0,  transition: "all 0.3s ease", transform: hovered ? "translateX(0)" : "translateX(8px)",}}/>
                   </IconButton>
                 </Box>
@@ -537,7 +531,7 @@ export default function CustomerDetail() {
                         </MenuItem>
                       ))}
                     </TextField>
-                    <IconButton title='Confirm Update' onClick={handleUpdateStatus} sx={{p:'2px'}}>
+                    <IconButton title='Confirm Update' onClick={() => setUpdateStatus(true)} sx={{p:'2px'}}>
                       <CheckIcon sx={{fontSize: '13px'}}/>
                     </IconButton>
                     <IconButton title='Cancel' onClick={() => setIsUpdatingStatus(false)} sx={{p:'2px'}}>
@@ -728,8 +722,8 @@ export default function CustomerDetail() {
             disableElevation
             sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2 }}
             onClick={() => {
+              handleUpdateStatus();
               setUpdateStatus(false);
-              setIsUpdatingStatus(true);
               handleEditStatus()
             }}
           >

--- a/src/pages/app/Deals/AddDeal.tsx
+++ b/src/pages/app/Deals/AddDeal.tsx
@@ -130,7 +130,7 @@ export default function AddDeal() {
               dispatch(clearError())
               navigate('/app/deals')
             }}
-            sx={{ alignSelf: 'start', ml: '-8px', textTransform: 'none', fontWeight: 600, color: 'text.secondary' }}>
+            sx={{ alignSelf: 'start', ml: '-8px', textTransform: 'none', fontWeight: 600, color: 'primary.main' }}>
             Back
           </Button>
            <Box sx={{width: '100%'}}>

--- a/src/pages/app/Deals/AddDealByID.tsx
+++ b/src/pages/app/Deals/AddDealByID.tsx
@@ -120,7 +120,7 @@ export default function AddDealByID() {
               dispatch(clearError())
               navigate(`/app/contacts/${id}`)
             }}
-            sx={{ alignSelf: 'start', ml: '-8px', textTransform: 'none', fontWeight: 600, color: 'text.secondary' }}>
+            sx={{ alignSelf: 'start', ml: '-8px', textTransform: 'none', fontWeight: 600, color: 'primary.main' }}>
             Back
           </Button>
           <Box sx={{width: '100%'}}>

--- a/src/pages/app/Deals/Deals.tsx
+++ b/src/pages/app/Deals/Deals.tsx
@@ -456,10 +456,6 @@ export default function Deals() {
       'Closed Won': '',
       'Closed Lost': '',
     });
-
-  // UI-only additions: reduced-motion preference and the ref used as the
-  // IntersectionObserver root so each column lazy-mounts as it scrolls
-  // into view. Neither is read by, or affects, any business logic below.
   const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
   const boardScrollRef = useRef<HTMLDivElement>(null);
 

--- a/src/pages/app/Leads/LeadDetails.tsx
+++ b/src/pages/app/Leads/LeadDetails.tsx
@@ -379,7 +379,7 @@ export default function LeadDetails() {
     setTimeout(() => setSuccessMessage(''), 3000);
   }
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangePersonal = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormPersonal({ ...formPersonal, [e.target.name]: e.target.value });
   };
 
@@ -391,7 +391,7 @@ export default function LeadDetails() {
     setFormCareer({ ...formCareer, [e.target.name]: e.target.value });
   };
 
-  const handleSave = async () => {
+  const handleSavePersonal = async () => {
     if (loading) return;
     try {
       await dispatch(updateLeadPersonal({ id: lead.id, personal: formPersonal as LeadPersonal })).unwrap();
@@ -439,6 +439,7 @@ export default function LeadDetails() {
 
   const handleEditSource = () => {
       setSelectedSource(lead?.source ?? "");
+      setIsUpdatingSource(true);
     };
   
   
@@ -462,6 +463,7 @@ export default function LeadDetails() {
 
   const handleEditPreferredTime = () => {
     setSelectedPreferredTime(lead?.preferred_contact_time ?? "");
+    setIsUpdatingPreferredTime(true);
   };
   
   
@@ -636,45 +638,57 @@ export default function LeadDetails() {
             </Box>
             </Typography>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1.25, justifyContent: { xs: 'center', sm: 'flex-start' } }}>
-              <Chip
-                label={lead.status}
+              <Paper
                 title="Status"
-                size='small'
+                elevation={2}
                 sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
                   px: 1,
-                  // fontWeight: 700,
-                  fontSize: 12,
+                  py: 0.5,
+                  fontSize: '11px',
+                  fontWeight: 700,
+                  letterSpacing: '0.6px',
                   cursor: 'pointer',
                   transition: 'opacity 0.15s ease',
-                  '&:hover': { opacity: 0.85 },
-                  border: lead.status === 'Contacted' ? '1px solid #7a7a7a98' : 'none',
+                  border:
+                    lead.status === 'Contacted'
+                      ? '1px solid #7a7a7a98'
+                      : 'none',
                   backgroundColor: STATUS_COLORS[lead.status],
-                  color: lead.status === 'Contacted' ? 'black' : 'white'
+                  color: lead.status === 'Contacted' ? 'black' : 'white',
+                  borderRadius: 10,
                 }}
-              />
+              >
+                {lead.status}
+              </Paper>
               {!isUpdatingSource ? (
                 <Box
                   sx={{display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative'}}
                   onMouseEnter={() => setHoveredSource(true)}
                   onMouseLeave={() => setHoveredSource(false)}
                 >
-                  <Chip
-                    label={lead?.source}
+                  <Paper
                     title="Source"
-                    size='small'
+                    elevation={2}
                     sx={{
-                      px: '4px',
-                      py: '1px',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      px: 1,
+                      py: 0.5,
                       fontSize: '11px',
                       fontWeight: 700,
-                      color: '#252525e7',
                       letterSpacing: '0.6px',
                       cursor: 'pointer',
                       borderRadius: 10,
                       opacity: hoveredSource ? 0.4 : 1,
                     }}
-                  />
-                  <IconButton onClick={() => setIsUpdatingSource(true)} title='Update Source' sx={{p:'1px', position: 'absolute'}}>
+                  >
+                    {lead?.source}
+                  </Paper>
+                  <IconButton onClick={handleEditSource} title='Update Source' sx={{p:'1px', position: 'absolute'}}>
                     <ModeEditIcon sx={{ fontSize: '15px', opacity: hoveredSource ? 1 : 0,  transition: "all 0.3s ease", transform: hoveredSource ? "translateX(0)" : "translateX(8px)",}}/>
                   </IconButton>
                 </Box>
@@ -722,23 +736,26 @@ export default function LeadDetails() {
                   onMouseEnter={() => setHoveredPreferredTime(true)}
                   onMouseLeave={() => setHoveredPreferredTime(false)}
                 >
-                  <Chip
-                    label={lead?.preferred_contact_time}
+                  <Paper
                     title="Preferred contact time"
-                    size='small'
+                    elevation={2}
                     sx={{
-                      px: '4px',
-                      py: '1px',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      px: 1,
+                      py: 0.5,
                       fontSize: '11px',
                       fontWeight: 700,
-                      color: '#252525e7',
                       letterSpacing: '0.6px',
                       cursor: 'pointer',
                       borderRadius: 10,
                       opacity: hoveredPreferredTime ? 0.4 : 1,
                     }}
-                  />
-                  <IconButton onClick={() => setIsUpdatingPreferredTime(true)} title='Update Preferred contact time' sx={{p:'1px', position: 'absolute'}}>
+                  >
+                    {lead?.preferred_contact_time}
+                  </Paper>
+                  <IconButton onClick={handleEditPreferredTime} title='Update Preferred contact time' sx={{p:'1px', position: 'absolute'}}>
                     <ModeEditIcon sx={{ fontSize: '15px', opacity: hoveredPreferredTime ? 1 : 0,  transition: "all 0.3s ease", transform: hoveredPreferredTime ? "translateX(0)" : "translateX(8px)",}}/>
                   </IconButton>
                 </Box>
@@ -922,7 +939,7 @@ export default function LeadDetails() {
                 label="First Name"
                 name="first_name"
                 required
-                onChange={handleChange}
+                onChange={handleChangePersonal}
                 value={formPersonal.first_name || ''}
                 size="small"
                 fullWidth
@@ -932,7 +949,7 @@ export default function LeadDetails() {
                 label="Last Name"
                 name="last_name"
                 required
-                onChange={handleChange}
+                onChange={handleChangePersonal}
                 value={formPersonal.last_name || ''}
                 size="small"
                 fullWidth
@@ -945,7 +962,7 @@ export default function LeadDetails() {
                 select
                 label="Suffix"
                 name="suffix"
-                onChange={handleChange}
+                onChange={handleChangePersonal}
                 value={formPersonal.suffix || ''}
                 size="small"
                 fullWidth
@@ -971,7 +988,7 @@ export default function LeadDetails() {
                 name="phone"
                 placeholder='63+'
                 required
-                onChange={handleChange}
+                onChange={handleChangePersonal}
                 value={formPersonal.phone || ''}
                 size="small"
                 fullWidth
@@ -983,7 +1000,7 @@ export default function LeadDetails() {
               label="Email"
               name="email"
               required
-              onChange={handleChange}
+              onChange={handleChangePersonal}
               value={formPersonal.email || ''}
               size="small"
               fullWidth
@@ -995,7 +1012,7 @@ export default function LeadDetails() {
                 select
                 label="Gender"
                 name="gender"
-                onChange={handleChange}
+                onChange={handleChangePersonal}
                 value={formPersonal.gender || ''}
                 size="small"
                 fullWidth
@@ -1013,7 +1030,7 @@ export default function LeadDetails() {
                 name="birth_date"
                 type="date"
                 value={formPersonal.birth_date || ''}
-                onChange={handleChange}
+                onChange={handleChangePersonal}
                 slotProps={{ inputLabel: { shrink: true } }}
                 size="small"
                 fullWidth
@@ -1044,7 +1061,7 @@ export default function LeadDetails() {
               <Button
                 variant="contained"
                 disableElevation
-                onClick={handleSave}
+                onClick={handleSavePersonal}
                 disabled={!formPersonal.first_name || !formPersonal.email || !formPersonal.last_name || !formPersonal.phone || loading}
                 startIcon={loading ? <CircularProgress size={14} color="inherit" /> : undefined}
                 sx={saveBtnSx}
@@ -1436,11 +1453,7 @@ export default function LeadDetails() {
             variant="contained"
             disableElevation
             sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2 }}
-            onClick={() => {
-              handleUpdateSource();
-              setUpdateSource(false);
-              handleEditSource()
-            }}
+            onClick={handleUpdateSource}
           >
             Yes
           </Button>
@@ -1466,11 +1479,7 @@ export default function LeadDetails() {
             variant="contained"
             disableElevation
             sx={{ textTransform: 'none', fontWeight: 700, borderRadius: 2 }}
-            onClick={() => {
-              handleUpdatePreferredTime();
-              setUpdatePreferredTime(false);
-              handleEditPreferredTime()
-            }}
+            onClick={handleUpdatePreferredTime}
           >
             Yes
           </Button>

--- a/src/pages/app/Leads/LeadDetails.tsx
+++ b/src/pages/app/Leads/LeadDetails.tsx
@@ -64,7 +64,6 @@ import type { RootState } from '../../../store/store';
 import { fixLeafletIcons } from '../../../utils/fixLeafletIcons';
 import { DEPARTMENTS, GENDERS, INDUSTRIES, PREFERRED_CONTACT_TIMES, SOURCES, SUFFIXES, type Gender, type PreferredTime, type Priority, type Source, type Suffix } from '../../../types/global';
 import ErrorAlert from '../../../components/Error';
-import SuccessAlert from '../../../components/Success';
 import { formatName } from '../../../utils/formatText';
 import type { LeadCareer, LeadPersonal, LeadSocials, LeadStatus } from '../../../types/lead';
 import { clearError, deleteLead, updateLeadCareer, updateLeadNotes, updateLeadPersonal, updateLeadPreferredTime, updateLeadSocials, updateLeadSource } from '../../../store/leadsSlice';
@@ -280,7 +279,6 @@ export default function LeadDetails() {
   const [formSocials, setFormSocials] = useState<SocialsForm>({});
   const [formCareer, setFormCareer] = useState<CareerForm>({});
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [successMessage, setSuccessMessage] = useState('');
   const [newNotes, setNewNotes] = useState("");
   const [hoveredNotes, setHoveredNotes] = useState(false);
   const [isEditingNotes, setIsEditingNotes] = useState(false);
@@ -374,11 +372,6 @@ export default function LeadDetails() {
     setIsEditingCareer(true);
   };
 
-  const success = (msg: string) => {
-    setSuccessMessage(msg);
-    setTimeout(() => setSuccessMessage(''), 3000);
-  }
-
   const handleChangePersonal = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormPersonal({ ...formPersonal, [e.target.name]: e.target.value });
   };
@@ -396,7 +389,6 @@ export default function LeadDetails() {
     try {
       await dispatch(updateLeadPersonal({ id: lead.id, personal: formPersonal as LeadPersonal })).unwrap();
       setIsEditingPersonal(false);
-      success("Lead updated successfully")
     } catch {
       //Error in state
     }
@@ -408,7 +400,6 @@ export default function LeadDetails() {
     try {
       await dispatch(updateLeadSocials({ id: lead.id, socials: formSocials as LeadSocials })).unwrap();
       setIsEditingSocials(false);
-      success("Lead updated successfully")
     } catch {
       //Error in state
     }
@@ -420,7 +411,6 @@ export default function LeadDetails() {
     try {
       await dispatch(updateLeadCareer({ id: lead.id, career: formCareer as LeadCareer })).unwrap();
       setIsEditingCareer(false);
-      success("Lead updated successfully")
     } catch {
       //Error in state
     }
@@ -543,14 +533,6 @@ export default function LeadDetails() {
 
   return (
     <Box sx={{ maxWidth: 800, mx: 'auto', pb: 4, px: { xs: 2, sm: 3, md: 0 } }}>
-
-      <Collapse in={!!successMessage} unmountOnExit>
-        <Box sx={{ my: 2, width: '100%' }}>
-          <SuccessAlert
-            message={successMessage}
-          />
-        </Box>
-      </Collapse>
 
       <Collapse in={!!error} unmountOnExit>
       {error && (

--- a/src/pages/app/Leads/LeadDetails.tsx
+++ b/src/pages/app/Leads/LeadDetails.tsx
@@ -2,8 +2,6 @@ import { forwardRef, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector} from 'react-redux';
 import type { AppDispatch } from '../../../store/store';
-import {  deleteContact, clearError, updateContactPersonal, updateContactSocials, updateContactCareer, updateContactNotes, updateContactSource, updateContactPreferredTime, } from '../../../store/contactsSlice';
-import { type ContactCareer, type ContactPersonal, type ContactSocials, type ContactStatus, } from "../../../types/contact";
 import 'leaflet/dist/leaflet.css';
 
 
@@ -53,32 +51,31 @@ import TelegramIcon from '@mui/icons-material/Telegram';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import MusicNoteIcon from '@mui/icons-material/MusicNote';
 import LanguageIcon from '@mui/icons-material/Language';
-import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
-import ShareIcon from '@mui/icons-material/Share';
-import WorkOutlineIcon from '@mui/icons-material/WorkOutline';
-import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import CheckIcon from '@mui/icons-material/Check';
 import CancelIcon from '@mui/icons-material/Cancel';
 import ModeEditIcon from '@mui/icons-material/ModeEdit';
 import EditNoteIcon from '@mui/icons-material/EditNote';
+import ShareIcon from '@mui/icons-material/Share';
+import WorkOutlineIcon from '@mui/icons-material/WorkOutline';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
 import type { RootState } from '../../../store/store';
 import { fixLeafletIcons } from '../../../utils/fixLeafletIcons';
 import { DEPARTMENTS, GENDERS, INDUSTRIES, PREFERRED_CONTACT_TIMES, SOURCES, SUFFIXES, type Gender, type PreferredTime, type Priority, type Source, type Suffix } from '../../../types/global';
 import ErrorAlert from '../../../components/Error';
 import SuccessAlert from '../../../components/Success';
 import { formatName } from '../../../utils/formatText';
-import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import type { LeadCareer, LeadPersonal, LeadSocials, LeadStatus } from '../../../types/lead';
+import { clearError, deleteLead, updateLeadCareer, updateLeadNotes, updateLeadPersonal, updateLeadPreferredTime, updateLeadSocials, updateLeadSource } from '../../../store/leadsSlice';
 
 fixLeafletIcons();
 
-const STATUS_COLORS: Record<ContactStatus, string> = {
-  Contacted: '#ffffff',
-  Opportunity: '#ffbb29',
-  Customer: '#AD7450',
-  Lost: '#7a0000',
-  Churned: '#000000',
+const STATUS_COLORS: Record<LeadStatus, string> = {
+  New: '#8d8d8d',
+  Contacted: '#f5f5f5',
+  Qualified: '#55ade7',
+  Closed: '#a83020',
 }
 
 const PRIORITY_COLORS: Record<Priority, string> = {
@@ -87,7 +84,6 @@ const PRIORITY_COLORS: Record<Priority, string> = {
   Low: '#ffffff00',
 }
 
-// ---- purely presentational helpers (no data/logic impact) ----
 const AVATAR_PALETTE = [
   "#4f5fce",
   "#0f8f7a",
@@ -260,24 +256,22 @@ const SocialLink = ({
     );
   };
 
-export default function ContactDetail() {
+export default function LeadDetails() {
   
   const { id } = useParams<{id: string }>();
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
     
   const themeMode = useSelector((state: RootState) => state.ui.themeMode);
-  const contact = useSelector((state: RootState) =>
-    state.contacts.items.find((c) => c.id === id)
+  const lead = useSelector((state: RootState) =>
+    state.leads.items.find((c) => c.id === id)
   );
-  const customer = useSelector((state: RootState) =>
-    state.customers.items.find((c) => c.contact_id === contact?.id)
-  );
-  const { loading, error } = useSelector((state: RootState) => state.contacts);
 
-  type PersonalForm = Partial<ContactPersonal>;
-  type SocialsForm = Partial<ContactSocials>;
-  type CareerForm = Partial<ContactCareer>;
+  const { loading, error } = useSelector((state: RootState) => state.leads);
+
+  type PersonalForm = Partial<LeadPersonal>;
+  type SocialsForm = Partial<LeadSocials>;
+  type CareerForm = Partial<LeadCareer>;
 
   const [isEditingPersonal, setIsEditingPersonal] = useState(false);
   const [isEditingSocials, setIsEditingSocials] = useState(false);
@@ -298,12 +292,13 @@ export default function ContactDetail() {
   const [isUpdatingPreferredTime, setIsUpdatingPreferredTime] = useState(false);
   const [selectedPreferredTime, setSelectedPreferredTime] = useState<PreferredTime | "">("");
   const [updatePreferredTime, setUpdatePreferredTime] = useState(false);
+  
 
-  if (!contact) {
+  if (!lead) {
     return (
       <Box sx={{ textAlign: 'center', mt: 8, px: 2 }}>
         <Typography variant="h6" color="text.secondary">
-          Contact not found
+          Lead not found
         </Typography>
         <Button
           startIcon={<ArrowBackIcon />}
@@ -319,107 +314,62 @@ export default function ContactDetail() {
     );
   }
 
-  const handleEditNotes = () => {
-    setNewNotes(contact?.notes ?? "");
-    setIsEditingNotes(true);
-  };
-
-  const handleNewNotes = async () => {
-    if (!contact || !newNotes) return;
-
-    try {
-      await dispatch(
-        updateContactNotes({
-          id: contact.id,
-          notes: newNotes,
-        })
-      ).unwrap();
-      
-      setIsEditingNotes(false);
-    } catch {
-      //Error in state
-    }
-  }
-
-  const handleEditSource = () => {
-        setSelectedSource(contact?.source ?? "");
-      };
-    
-    
-      const handleUpdateSource = async () => {
-        if (!contact || !selectedSource) return;
-    
-        try {
-          await dispatch(
-            updateContactSource({
-              id: contact.id,
-              source: selectedSource,
-            })
-          ).unwrap();
-    
-          setUpdateSource(false);
-          setIsUpdatingSource(false);
-        } catch {
-          //Error in state
-        }
-      };
-  
-    const handleEditPreferredTime = () => {
-      setSelectedPreferredTime(contact?.preferred_contact_time ?? "");
+    const handleEditNotes = () => {
+      setNewNotes(lead?.notes ?? "");
+      setIsEditingNotes(true);
     };
-    
-    
-    const handleUpdatePreferredTime = async () => {
-      if (!contact || !selectedPreferredTime) return;
+  
+    const handleNewNotes = async () => {
+      if (!lead || !newNotes) return;
+  
       try {
         await dispatch(
-          updateContactPreferredTime({
-            id: contact.id,
-            preferredTime: selectedPreferredTime,
+          updateLeadNotes({
+            id: lead.id,
+            notes: newNotes,
           })
         ).unwrap();
-  
-        setUpdatePreferredTime(false);
-        setIsUpdatingPreferredTime(false);
+        
+        setIsEditingNotes(false);
       } catch {
         //Error in state
       }
-    };
+    }
 
   const handleEditStart = () => {
     setFormPersonal({
-      first_name: contact.first_name,
-      last_name: contact.last_name,
-      suffix: contact.suffix as Suffix,
-      gender: contact.gender as Gender,
-      birth_date: contact.birth_date || null,
-      email: contact.email,
-      phone: contact.phone,
+      first_name: lead.first_name,
+      last_name: lead.last_name,
+      suffix: lead.suffix as Suffix,
+      gender: lead.gender as Gender,
+      birth_date: lead.birth_date || null,
+      email: lead.email,
+      phone: lead.phone,
     });
     setIsEditingPersonal(true);
   };
 
   const handleEditSocials = () => {
     setFormSocials({
-      facebook: contact.facebook || '',
-      x: contact.x || '',
-      whatsapp: contact.whatsapp || '',
-      linkedin: contact.linkedin || '',
-      instagram: contact.instagram || '',
-      telegram: contact.telegram || '',
-      tiktok: contact.tiktok || '',
-      viber: contact.viber || '',
+      facebook: lead.facebook || '',
+      x: lead.x || '',
+      whatsapp: lead.whatsapp || '',
+      linkedin: lead.linkedin || '',
+      instagram: lead.instagram || '',
+      telegram: lead.telegram || '',
+      tiktok: lead.tiktok || '',
+      viber: lead.viber || '',
     });
     setIsEditingSocials(true);
   };
 
   const handleEditCareer = () => {
     setFormCareer({
-      company_name: contact.company_name || '',
-      industry: contact.industry || '',
-      position: contact.position || '',
-      department: contact.department || '',
-      website: contact.website || '',
+      company_name: lead.company_name || '',
+      industry: lead.industry || '',
+      position: lead.position || '',
+      department: lead.department || '',
+      website: lead.website || '',
     });
     setIsEditingCareer(true);
   };
@@ -444,9 +394,9 @@ export default function ContactDetail() {
   const handleSave = async () => {
     if (loading) return;
     try {
-      await dispatch(updateContactPersonal({ id: contact.id, personal: formPersonal as ContactPersonal })).unwrap();
+      await dispatch(updateLeadPersonal({ id: lead.id, personal: formPersonal as LeadPersonal })).unwrap();
       setIsEditingPersonal(false);
-      success("Contact updated successfully")
+      success("Lead updated successfully")
     } catch {
       //Error in state
     }
@@ -456,11 +406,9 @@ export default function ContactDetail() {
   const handleSaveSocials = async () => {
     if (loading) return;
     try {
-      await dispatch(updateContactSocials({ id: contact.id, socials: formSocials as ContactSocials })).unwrap();
+      await dispatch(updateLeadSocials({ id: lead.id, socials: formSocials as LeadSocials })).unwrap();
       setIsEditingSocials(false);
-
-      
-      success("Contact updated successfully")
+      success("Lead updated successfully")
     } catch {
       //Error in state
     }
@@ -470,9 +418,9 @@ export default function ContactDetail() {
   const handleSaveCareer = async () => {
     if (loading) return;
     try {
-      await dispatch(updateContactCareer({ id: contact.id, career: formCareer as ContactCareer })).unwrap();
+      await dispatch(updateLeadCareer({ id: lead.id, career: formCareer as LeadCareer })).unwrap();
       setIsEditingCareer(false);
-      success("Contact updated successfully")
+      success("Lead updated successfully")
     } catch {
       //Error in state
     }
@@ -482,10 +430,55 @@ export default function ContactDetail() {
   const handleDeleteConfirm = async () => {
     if (loading) return;
     try {
-      await dispatch(deleteContact(contact.id)).unwrap();
-      navigate('/app/contacts');
+      await dispatch(deleteLead(lead.id)).unwrap();
+      navigate('/app/leads');
     } catch {
       //Error in State
+    }
+  };
+
+  const handleEditSource = () => {
+      setSelectedSource(lead?.source ?? "");
+    };
+  
+  
+    const handleUpdateSource = async () => {
+      if (!lead || !selectedSource) return;
+  
+      try {
+        await dispatch(
+          updateLeadSource({
+            id: lead.id,
+            source: selectedSource,
+          })
+        ).unwrap();
+  
+        setUpdateSource(false);
+        setIsUpdatingSource(false);
+      } catch {
+        //Error in state
+      }
+    };
+
+  const handleEditPreferredTime = () => {
+    setSelectedPreferredTime(lead?.preferred_contact_time ?? "");
+  };
+  
+  
+  const handleUpdatePreferredTime = async () => {
+    if (!lead || !selectedPreferredTime) return;
+    try {
+      await dispatch(
+        updateLeadPreferredTime({
+          id: lead.id,
+          preferredTime: selectedPreferredTime,
+        })
+      ).unwrap();
+
+      setUpdatePreferredTime(false);
+      setIsUpdatingPreferredTime(false);
+    } catch {
+      //Error in state
     }
   };
 
@@ -515,7 +508,7 @@ export default function ContactDetail() {
     }
   }
 
-  const fullName = formatName(contact.first_name, contact.last_name);
+  const fullName = formatName(lead.first_name, lead.last_name);
 
   const cancelBtnSx = {
     textTransform: 'none',
@@ -567,7 +560,7 @@ export default function ContactDetail() {
         )}
       </Collapse>
 
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 1 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'left', flexWrap: 'wrap', gap: 1 }}>
         <Button
           startIcon={<ArrowBackIcon/>}
           onClick={() => {
@@ -584,24 +577,6 @@ export default function ContactDetail() {
           }}>
           Back
         </Button>
-        {(contact.status === 'Customer' && customer) && (
-        <Button
-          endIcon={<ArrowForwardIcon/>}
-          onClick={() => {
-            navigate(`/app/customers/${customer.id}`);
-            dispatch(clearError());
-          } }
-          sx={{
-            alignSelf: 'start',
-            textTransform: 'none',
-            fontWeight: 600,
-            borderRadius: 2,
-            transition: 'transform 0.2s ease',
-            '&:hover': { transform: 'translateX(2px)' },
-          }}>
-          Customer Profile
-        </Button>
-        )}
       </Box>
       <Paper
         variant="outlined"
@@ -610,14 +585,14 @@ export default function ContactDetail() {
           p: { xs: 2.5, sm: 3, md: 4 },
           borderRadius: 3,
           mb: 3,
-          mt: 2,
+          mt: 0.5,
           borderColor: 'divider',
           animation: `${fadeInUp} 0.45s ease-out`,
           '@media (prefers-reduced-motion: reduce)': { animation: 'none' },
         }}
       >
         <Box sx={{display: 'flex', justifyContent: 'center',mb: 2}}>
-          <Typography sx={{border: '1px solid #ccc', height: '100%', borderRadius: 10,px: 2, py: 0.5, fontSize: 10, fontWeight: 700, letterSpacing: '0.15em',}}>CONTACT</Typography>
+          <Typography sx={{border: '1px solid #ccc', height: '100%', borderRadius: 10,px: 2, py: 0.5, fontSize: 10, fontWeight: 700, letterSpacing: '0.15em',}}>LEAD</Typography>
         </Box>
         <Box
           sx={{
@@ -635,35 +610,13 @@ export default function ContactDetail() {
                 width: { xs: 84, sm: 100 },
                 height: { xs: 84, sm: 100 },
                 fontSize: { xs: 26, sm: 32 },
-                fontWeight: 700,  
+                fontWeight: 700,
                 bgcolor: stringToAvatarColor(fullName),
               }}
             >
               {getInitials(fullName)}
             </Avatar>
             <Box sx={{ display: 'flex', justifyContent: 'center'}}>
-              <Button 
-              title="Add new Deal for this contact"
-              startIcon={<AddCircleOutlineIcon sx={{ fontSize: '14px !important' }} />}
-              onClick={()=> navigate(`/app/deals/adddeal/${contact.id}`)}
-              sx={{
-                border: '1px solid',
-                borderColor: 'primary.main',
-                color: 'primary.main',
-                fontWeight: 700,
-                p: '3px 10px',
-                mt: 1,
-                fontSize: '10px',
-                borderRadius: 999,
-                textTransform: 'none',
-                whiteSpace: 'nowrap',
-                transition: 'background-color 0.2s ease',
-                '&:hover': {
-                  bgcolor: (theme: Theme) => alpha(theme.palette.primary.main, 0.08),
-                },
-              }}>
-                Add deal
-              </Button>
             </Box>
           </Box>
           <Box sx={{ flex: 1, minWidth: 0, width: '100%', overflowWrap: "anywhere", wordBreak: "break-word", textAlign: { xs: 'center', sm: 'left' } }}>
@@ -677,26 +630,26 @@ export default function ContactDetail() {
                 fontSize: { xs: '1.5rem', sm: '1.85rem', md: '2.125rem' },
               }}
             >
-              {fullName} {contact.suffix} 
-              <Box title={`${contact.priority} Priority`} component="span" sx={{ ml: 1, cursor: 'pointer', display: "flex", width: 30, height: 30, flexShrink: 0 }}>
-              {priorityIcon(contact.priority)}
+              {fullName} {lead.suffix} 
+              <Box title={`${lead.priority} Priority`} component="span" sx={{ ml: 1, cursor: 'pointer', display: "flex", width: 30, height: 30, flexShrink: 0 }}>
+              {priorityIcon(lead.priority)}
             </Box>
             </Typography>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mt: 1.25, justifyContent: { xs: 'center', sm: 'flex-start' } }}>
               <Chip
-                label={contact.status}
+                label={lead.status}
                 title="Status"
                 size='small'
                 sx={{
                   px: 1,
-                  fontWeight: 700,
+                  // fontWeight: 700,
                   fontSize: 12,
                   cursor: 'pointer',
                   transition: 'opacity 0.15s ease',
                   '&:hover': { opacity: 0.85 },
-                  border: contact.status === 'Contacted' ? '1px solid #7a7a7a98' : 'none',
-                  backgroundColor: STATUS_COLORS[contact.status],
-                  color: contact.status === 'Contacted' ? 'black' : 'white'
+                  border: lead.status === 'Contacted' ? '1px solid #7a7a7a98' : 'none',
+                  backgroundColor: STATUS_COLORS[lead.status],
+                  color: lead.status === 'Contacted' ? 'black' : 'white'
                 }}
               />
               {!isUpdatingSource ? (
@@ -706,7 +659,7 @@ export default function ContactDetail() {
                   onMouseLeave={() => setHoveredSource(false)}
                 >
                   <Chip
-                    label={contact?.source}
+                    label={lead?.source}
                     title="Source"
                     size='small'
                     sx={{
@@ -770,7 +723,7 @@ export default function ContactDetail() {
                   onMouseLeave={() => setHoveredPreferredTime(false)}
                 >
                   <Chip
-                    label={contact?.preferred_contact_time}
+                    label={lead?.preferred_contact_time}
                     title="Preferred contact time"
                     size='small'
                     sx={{
@@ -828,8 +781,8 @@ export default function ContactDetail() {
                   </Box>
               )}
               <Chip
-                label={formatName(contact.owner.profile.first_name, contact.owner.profile.last_name)}
-                title="Contact owner"
+                label={formatName(lead.owner.profile.first_name, lead.owner.profile.last_name)}
+                title="Lead owner"
                 size='small'
                 sx={{
                   px: 1,
@@ -857,7 +810,7 @@ export default function ContactDetail() {
                   mt: 1
                 })}>
                 <Typography title="Notes" fontWeight={500} fontSize={12} color="text.secondary" sx={{cursor: 'pointer', minHeight: 40, width: '95%' }}>
-                  {contact?.notes}
+                  {lead?.notes}
                 </Typography>
                 <Box width={'5%'} >
                   <IconButton onClick={() => {
@@ -932,9 +885,9 @@ export default function ContactDetail() {
             <SectionHeader icon={<PersonOutlineIcon fontSize="small" />} title="Personal Details" onEdit={handleEditStart} />
             <Box sx={twoColSx}>
               <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                <InfoRow icon={<PersonIcon fontSize="small" />} label="Full name" value={`${fullName} ${contact.suffix ?? ''}`} />
-                <InfoRow icon={<EmailIcon fontSize="small" />} label="Email address" value={contact.email || 'Not Provided'} />
-                <InfoRow icon={<PhoneIcon fontSize="small" />} label="Phone number" value={contact.phone || 'Not Provided'} />
+                <InfoRow icon={<PersonIcon fontSize="small" />} label="Full name" value={`${fullName} ${lead.suffix ?? ''}`} />
+                <InfoRow icon={<EmailIcon fontSize="small" />} label="Email address" value={lead.email || 'Not Provided'} />
+                <InfoRow icon={<PhoneIcon fontSize="small" />} label="Phone number" value={lead.phone || 'Not Provided'} />
               </Box>
               <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                 <InfoRow
@@ -945,10 +898,10 @@ export default function ContactDetail() {
                     </Box>
                   }
                   label="Gender"
-                  value={contact.gender}
+                  value={lead.gender}
                 />
-                <InfoRow icon={<CakeIcon fontSize="small" />} label="Date of Birth" value={!contact.birth_date ? 'Not Provided' : contact.birth_date} />
-                <InfoRow icon={<CalendarTodayIcon fontSize="small" />} label="Added on" value={formattedDate(contact.created_at)} />
+                <InfoRow icon={<CakeIcon fontSize="small" />} label="Date of Birth" value={!lead.birth_date ? 'Not Provided' : lead.birth_date} />
+                <InfoRow icon={<CalendarTodayIcon fontSize="small" />} label="Added on" value={formattedDate(lead.created_at)} />
               </Box>
             </Box>
           </Box>
@@ -1113,22 +1066,22 @@ export default function ContactDetail() {
                 <InfoRow
                   icon={<FacebookIcon fontSize="small" />}
                   label="Facebook"
-                  value={<SocialLink value={contact.facebook} href={`https://facebook.com/${contact.facebook}`} />}
+                  value={<SocialLink value={lead.facebook} href={`https://facebook.com/${lead.facebook}`} />}
                 />
                 <InfoRow
                   icon={<XIcon fontSize="small" />}
                   label="X / Twitter"
-                  value={<SocialLink value={contact.x} href={`https://x.com/${contact.x}`} />}
+                  value={<SocialLink value={lead.x} href={`https://x.com/${lead.x}`} />}
                 />
                 <InfoRow
                   icon={<InstagramIcon fontSize="small" />}
                   label="Instagram"
-                  value={<SocialLink value={contact.instagram} href={`https://instagram.com/${contact.instagram}`} />}
+                  value={<SocialLink value={lead.instagram} href={`https://instagram.com/${lead.instagram}`} />}
                 />
                 <InfoRow
                   icon={<LinkedInIcon fontSize="small" />}
                   label="LinkedIn"
-                  value={<SocialLink value={contact.linkedin} href={`https://linkedin.com/in/${contact.linkedin}`} />}
+                  value={<SocialLink value={lead.linkedin} href={`https://linkedin.com/in/${lead.linkedin}`} />}
                 />
               </Box>
 
@@ -1136,22 +1089,22 @@ export default function ContactDetail() {
                 <InfoRow
                   icon={<MusicNoteIcon fontSize="small" />}
                   label="Tiktok"
-                  value={<SocialLink value={contact.tiktok} href={`https://tiktok.com/@${contact.tiktok}`} />}
+                  value={<SocialLink value={lead.tiktok} href={`https://tiktok.com/@${lead.tiktok}`} />}
                 />
                 <InfoRow
                   icon={<WhatsAppIcon fontSize="small" />}
                   label="WhatsApp"
-                  value={<SocialLink value={contact.whatsapp} href={`https://wa.me/${contact.whatsapp?.replace(/\D/g, "")}`} />}
+                  value={<SocialLink value={lead.whatsapp} href={`https://wa.me/${lead.whatsapp?.replace(/\D/g, "")}`} />}
                 />
                 <InfoRow
                   icon={<PhoneIcon fontSize="small" />}
                   label="Viber"
-                  value={<SocialLink value={contact.viber} href={`viber://chat?number=${contact.viber}`} />}
+                  value={<SocialLink value={lead.viber} href={`viber://chat?number=${lead.viber}`} />}
                 />
                 <InfoRow
                   icon={<TelegramIcon fontSize="small" />}
                   label="Telegram"
-                  value={<SocialLink value={contact.telegram} href={`https://t.me/${contact.telegram}`} />}
+                  value={<SocialLink value={lead.telegram} href={`https://t.me/${lead.telegram}`} />}
                 />
               </Box>
             </Box>
@@ -1271,21 +1224,20 @@ export default function ContactDetail() {
 
         <Divider sx={{ mb: 1, mt: 4 }} />
 
-        {/* ---------------- Professional Details ---------------- */}
         <Collapse in={!isEditingCareer} unmountOnExit>
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
             <SectionHeader icon={<WorkOutlineIcon fontSize="small" />} title="Professional Details" onEdit={handleEditCareer} />
 
             <Box sx={twoColSx}>
               <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                <InfoRow icon={<AccountTreeIcon fontSize="small" />} label="Industry" value={contact.industry || 'Not Provided'} />
-                <InfoRow icon={<BusinessIcon fontSize="small" />} label="Company" value={contact.company_name || 'Not Provided'} />
-                <InfoRow icon={<LanguageIcon fontSize="small" />} label="Website" value={contact.website || 'Not Provided'} />
+                <InfoRow icon={<AccountTreeIcon fontSize="small" />} label="Industry" value={lead.industry || 'Not Provided'} />
+                <InfoRow icon={<BusinessIcon fontSize="small" />} label="Company" value={lead.company_name || 'Not Provided'} />
+                <InfoRow icon={<LanguageIcon fontSize="small" />} label="Website" value={lead.website || 'Not Provided'} />
               </Box>
 
               <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-                <InfoRow icon={<AccountTreeIcon fontSize="small" />} label="Department" value={contact.department || 'Not Provided'} />
-                <InfoRow icon={<WorkIcon fontSize="small" />} label="Position" value={contact.position || 'Not Provided'} />
+                <InfoRow icon={<AccountTreeIcon fontSize="small" />} label="Department" value={lead.department || 'Not Provided'} />
+                <InfoRow icon={<WorkIcon fontSize="small" />} label="Position" value={lead.position || 'Not Provided'} />
               </Box>
             </Box>
           </Box>
@@ -1420,13 +1372,13 @@ export default function ContactDetail() {
             >
               <WarningAmberRoundedIcon />
             </Box>
-            Delete contact?
+            Delete lead?
           </DialogTitle>
           <DialogContent>
             <DialogContentText sx={{ fontSize: '0.9rem' }}>
               Are you sure you want to delete{' '}
               <Box component="span" sx={{ fontWeight: 700, color: 'text.primary' }}>
-                {contact.first_name} {contact.last_name}
+                {lead.first_name} {lead.last_name}
               </Box>
               ? This action cannot be undone.
             </DialogContentText>
@@ -1462,6 +1414,7 @@ export default function ContactDetail() {
             </Button>
           </DialogActions>
         </Dialog>
+        
       )}
       <Dialog
         PaperProps={{ sx: { borderRadius: 3 } }}
@@ -1471,7 +1424,7 @@ export default function ContactDetail() {
         <DialogTitle sx={{ fontWeight: 700 }}>Confirmation</DialogTitle>
         <DialogContent>
           <Typography>
-            Are you sure you want to update source for <strong>{contact.first_name} {contact.last_name}</strong>?
+            Are you sure you want to update source for <strong>{lead.first_name} {lead.last_name}</strong>?
           </Typography>
         </DialogContent>
         <DialogActions sx={{ pb: 2, px: 3 }}>
@@ -1501,7 +1454,7 @@ export default function ContactDetail() {
         <DialogTitle sx={{ fontWeight: 700 }}>Confirmation</DialogTitle>
         <DialogContent>
           <Typography>
-            Are you sure you want to update preferred contact time for <strong>{contact.first_name} {contact.last_name}</strong>?
+            Are you sure you want to update preferred contact time for <strong>{lead.first_name} {lead.last_name}</strong>?
           </Typography>
         </DialogContent>
         <DialogActions sx={{ pb: 2, px: 3 }}>

--- a/src/pages/app/Leads/Leads.tsx
+++ b/src/pages/app/Leads/Leads.tsx
@@ -6,14 +6,13 @@ import type { AppDispatch, RootState } from "../../../store/store";
 
 
 import {
-  updateLead,
   deleteLead, 
   moveLeadLocally,
   updateLeadStatus,
   clearError,
   fetchLeadsLists,
 } from '../../../store/leadsSlice';
-import { LEAD_STATUSES, type Lead, type LeadStatus, type UpdateLead } from '../../../types/lead';
+import { LEAD_STATUSES, type Lead, type LeadStatus } from '../../../types/lead';
 
 import {
   DragDropContext,
@@ -34,13 +33,11 @@ import {
   DialogContent,
   DialogActions,
   TextField,
-  MenuItem,
   IconButton,
   Chip,
   Popover,
   InputAdornment,
   Divider,
-  Autocomplete,
   Avatar,
   Stack,
   Tooltip,
@@ -48,10 +45,7 @@ import {
   CircularProgress,
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
-import InfoIcon from '@mui/icons-material/Info';
 import DeleteIcon from '@mui/icons-material/Delete';
-import EditIcon from '@mui/icons-material/Edit';
-import CloseIcon from '@mui/icons-material/Close';
 import EmailIcon from '@mui/icons-material/Email';
 import CallIcon from '@mui/icons-material/Call';
 import SmsIcon from '@mui/icons-material/Sms';
@@ -59,13 +53,9 @@ import PersonIcon from '@mui/icons-material/Person';
 import SearchIcon from '@mui/icons-material/Search';
 import PriorityIcon from '@mui/icons-material/PriorityHighRounded';
 import AddIcon from '@mui/icons-material/Add';
-import WorkIcon from '@mui/icons-material/Work';
-import ShareIcon from '@mui/icons-material/Share';
-import NotesIcon from '@mui/icons-material/Notes';
-// import { useAuth } from "../../../hooks/useAuth";
 import ErrorAlert from "../../../components/Error";
 import RefreshIcon from "@mui/icons-material/Refresh";
-import { DEPARTMENTS, GENDERS, INDUSTRIES, PREFERRED_CONTACT_TIMES, PRIORITIES, SOURCES, SUFFIXES, type Gender, type PreferredTime, type Priority, type Source, type Suffix } from "../../../types/global";
+import { type Priority } from "../../../types/global";
 import { formatName, formatShortTitle } from "../../../utils/formatText";
 import { calculateAge } from "../../../utils/calculateAge";
 
@@ -79,39 +69,6 @@ const LAZY_CHUNK = 8;
 const LOAD_MORE_DELAY = 220;
 const CARD_TRANSITION =
   'box-shadow 0.2s cubic-bezier(0.4,0,0.2,1), border-color 0.2s ease, opacity 0.2s ease';
-
-const fieldSx = {
-  '& .MuiOutlinedInput-root': {
-    borderRadius: 1.5,
-    transition: 'border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease',
-  },
-  '& .MuiInputBase-input': { py: '6px', fontSize: 14 },
-  '& .Mui-disabled': { opacity: 1 },
-  '& .MuiOutlinedInput-root.Mui-disabled': { backgroundColor: 'transparent' },
-  '& .MuiOutlinedInput-root.Mui-disabled .MuiOutlinedInput-notchedOutline': { borderColor: 'transparent' },
-  '& .MuiOutlinedInput-root.Mui-disabled .MuiInputBase-input': { color: 'text.secondary' },
-} as const;
-
-function SectionHeader({ icon, children }: { icon: ReactNode; children: ReactNode }) {
-  return (
-    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 2, mb: 0.25 }}>
-      {icon}
-      <Typography
-        variant="caption"
-        sx={{
-          fontWeight: 700,
-          letterSpacing: '0.07em',
-          textTransform: 'uppercase',
-          color: 'text.secondary',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {children}
-      </Typography>
-      <Divider sx={{ flex: 1 }} />
-    </Box>
-  );
-}
 
 function PriorityBadge({ priority }: { priority: Priority }) {
   if (priority !== 'High' && priority !== 'Highest') return null;
@@ -268,22 +225,16 @@ function LeadCardSkeleton({ reducedMotion }: { reducedMotion: boolean }) {
 }
 
 export default function Leads() {
-  const themeMode = useSelector((state: RootState) => state.ui.themeMode);
   const {items: leads, loading, loaded,  error } = useSelector((state: RootState) => state.leads);
   const dispatch = useDispatch<AppDispatch>();
-  // const { user } = useAuth();
   const prefersReducedMotion = usePrefersReducedMotion();
-  const [isEditing, setIsEditing] = useState(false);
-  const [edit, setEdit] = useState(false);
   const [openCloseConfirmation, setOpenCloseConfirmation] = useState(false);
   const [dropResult, setDropResult] = useState<DropResult | null>(null)
   const [openDelete, setOpenDelete] = useState(false);
   const [invalid, setInvalid] = useState('');
   const [openAddContact, setOpenAddContact] = useState(false);
   const [openInvalid, setOpenInvalid] = useState(false);
-  const [openEditConfirmation, setOpenEditConfirmation] = useState(false);
   const [selectedLead, setSelectedLead] = useState<Lead | null>(null);
-  const [editingLead, setEditingLead] = useState<UpdateLead | null>();
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
   const [hoveredLead, setHoveredLead] = useState<Lead | null>(null);
@@ -335,39 +286,7 @@ export default function Leads() {
     Qualified: '',
     Closed: '',
   });
-  const [form, setForm] = useState<UpdateLead>({
-    id: "",
-    title: "",
-    first_name: "",
-    last_name: "",
-    suffix: null as Suffix,
-    email: null,
-    phone: null,
-    gender: "Prefer not to say" as Gender,
-    birth_date: null,
-    industry: "",
-    company_name: "",
-    department: "",
-    position: "",
-    website: "",
-    source: "Other" as Source,
-    priority: "Low" as Priority,
-    notes: "",
-    facebook: "",
-    x: "",
-    whatsapp: "",
-    linkedin: "",
-    instagram: "",
-    telegram: "",
-    tiktok: "",
-    viber: "",
-    preferred_contact_time: "Anytime" as PreferredTime,
-  });
 
-
-
-  
-  
   useEffect(() => {
     if (loading) return;
 
@@ -395,12 +314,6 @@ export default function Leads() {
   const handleCloseDelete = () => {
     setOpenDelete(false);
   }
-  const handleOpenEditConfirmation = () => {
-    setOpenEditConfirmation(true);
-  }
-  const handleCloseEditConfirmation = () => {
-    setOpenEditConfirmation(false);
-  } 
   const handleOpenAddContact = (result: DropResult) => {
     setOpenAddContact(true);
     if (!result.destination) return;
@@ -434,76 +347,6 @@ export default function Leads() {
 
   const handleDelete = async (id: string) => {
     await dispatch(deleteLead(id)).unwrap();
-  };
-
-  const handleOpenEdit = (lead: UpdateLead) => {
-    setForm({
-      id: lead.id,
-      title: lead.title,
-      first_name: lead.first_name,
-      last_name: lead.last_name,
-      suffix: lead.suffix as Suffix || null ,
-      gender: lead.gender as Gender,
-      birth_date: lead.birth_date || null ,
-      email: lead.email || null || '',
-      phone: lead.phone || null || '',
-      industry: lead.industry || '',
-      company_name: lead.company_name || '',
-      position: lead.position || '',
-      department: lead.department || '',
-      website: lead.website || '',
-      source: lead.source as Source,
-      priority: lead.priority as Priority,
-      notes: lead.notes || '',
-      preferred_contact_time: lead.preferred_contact_time as PreferredTime,
-      facebook: lead.facebook || '',
-      x: lead.x || '',
-      whatsapp: lead.whatsapp || '',
-      linkedin: lead.linkedin || '',
-      instagram: lead.instagram || '',
-      telegram: lead.telegram || '',
-      tiktok: lead.tiktok || '',
-      viber: lead.viber || '',
-    });
-    setEditingLead(lead);
-    setIsEditing(true);
-    setEdit(false);
-  };
-
-  const handleCloseEdit = () => {
-    dispatch(clearError());
-    setEdit(false);
-    setIsEditing(false);
-    setOpenEditConfirmation(false);
-  } 
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
-  };
-
-  const handleEditable = () => {
-    setEdit(true);
-  }
-  const handleNotEditable = () => {
-    setEdit(false);
-  }
-  const handleEdit = async () => {
-    if (loading) return;
-
-    try {
-      setEdit(false);
-    
-      if (!editingLead) return;
-
-      const leadId = editingLead.id;
-      await dispatch(updateLead({ id: leadId, lead: form as Lead })).unwrap();
-      setIsEditing(false);
-    } catch {
-      setIsEditing(true);
-      setEdit(true);
-      if (!editingLead) return;
-    }
-    
   };
 
   const handleOpenCloseConfirmation = () => {
@@ -795,14 +638,17 @@ const handleConfirmCloseLead = async () => {
           gap: { xs: 0.75, sm: 1 },
         }}
       >
-        <Typography sx={{ fontSize: { xs: 18, sm: 21, md: 23, lg: 28 } }} fontWeight={700}>
+        <Typography sx={{ fontSize: { sm: 16, md: 18, lg: 20 } }} fontWeight={700}>
           Leads
         </Typography>
 
         <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 0.5, sm: 0.75 } }}>
           <IconButton
             title="Add lead"
-            onClick={() => navigate("/app/addlead")}
+            onClick={() => {
+              clearError()
+              navigate("/app/leads/addlead")
+            }}
             sx={{
               width: { xs: 26, sm: 32 },
               height: { xs: 26, sm: 32 },
@@ -967,6 +813,7 @@ const handleConfirmCloseLead = async () => {
                       >
                         {(provided, snapshot) => (
                           <Card
+                            onClick={() => navigate(`/app/leads/${lead.id}`)}
                             ref={provided.innerRef}
                             {...provided.draggableProps}
                             {...provided.dragHandleProps}
@@ -1034,12 +881,6 @@ const handleConfirmCloseLead = async () => {
                                     title={`${lead.priority} Priority`}
                                    sx={{display: 'flex', alignItems: 'center', gap: 0.25, cursor: 'pointer', flexShrink: 0}}>
                                     <PriorityBadge priority={lead.priority} />
-                                     <IconButton
-                                      size="small"
-                                      onClick={() => handleOpenEdit(lead)}
-                                    >
-                                      <InfoIcon titleAccess="Full details" fontSize="small" />
-                                    </IconButton>
                                   </Box>
                                   
                                 </Box>
@@ -1097,17 +938,24 @@ const handleConfirmCloseLead = async () => {
                                 }}>
                                   <Stack direction="row" spacing={0.25}>
                                     <Tooltip title="Email lead">
-                                      <IconButton size="small" onClick={() => setOpenSnackbar(true)}>
+                                      <IconButton size="small" 
+                                        onClick={(e) => {
+                                          e.stopPropagation()
+                                          setOpenSnackbar(true)}}>
                                         <EmailIcon fontSize="small" sx={{ color: 'primary.main' }} />
                                       </IconButton>
                                     </Tooltip>
                                     <Tooltip title="Call lead">
-                                      <IconButton size="small" onClick={() => setOpenSnackbar(true)}>
+                                      <IconButton size="small" onClick={(e) => {
+                                          e.stopPropagation()
+                                          setOpenSnackbar(true)}}>
                                         <CallIcon fontSize="small" sx={{ color: 'primary.main' }} />
                                       </IconButton>
                                     </Tooltip>
                                     <Tooltip title="Message lead">
-                                      <IconButton size="small" onClick={() => setOpenSnackbar(true)}>
+                                      <IconButton size="small" onClick={(e) => {
+                                          e.stopPropagation()
+                                          setOpenSnackbar(true)}}>
                                         <SmsIcon fontSize="small" sx={{ color: 'primary.main' }} />
                                       </IconButton>
                                     </Tooltip>
@@ -1116,7 +964,10 @@ const handleConfirmCloseLead = async () => {
                                     <IconButton
                                       size="small"
                                       color="error"
-                                      onClick={() => handleOpenDelete(lead)}
+                                      onClick={(e) =>{
+                                        e.stopPropagation();
+                                         handleOpenDelete(lead)
+                                      }}
                                     >
                                       <DeleteIcon fontSize="small" />
                                     </IconButton>
@@ -1204,620 +1055,28 @@ const handleConfirmCloseLead = async () => {
                 Yes, delete
               </Button>
           </DialogActions>
-        </Dialog>
-        <Dialog  sx={{position: "absolute", maxHeight: 800, top: 100 }} maxWidth="md" open={isEditing} onClose={handleCloseEdit} PaperProps={{ sx: { borderRadius: 3, boxShadow: '0 24px 48px rgba(0,0,0,0.18)' } }}>
-          
-          <DialogActions sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            px: 2,
-            pt: 1.5,
-          }}>
-            <Tooltip title="Edit lead">
-              <IconButton
-                size="small"
-                onClick={handleEditable}
-                sx={{
-                  border: '1px solid',
-                  borderColor: 'primary.main',
-                  borderRadius: 2,
-                  transition: 'background-color 0.2s ease',
-                }}
-              >
-                <EditIcon titleAccess="Edit" color="primary" sx={{ fontSize: 16 }} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Close">
-              <IconButton
-                size="small"
-                onClick={handleCloseEdit}
-                sx={{
-                  bgcolor: 'error.main',
-                  color: 'common.white',
-                  borderRadius: 1,
-                  transition: 'background-color 0.2s ease',
-                  '&:hover': { bgcolor: 'error.dark' },
-                }}
-              >
-                <CloseIcon titleAccess="Close" sx={{ fontSize: 16 }} />
-              </IconButton>
-            </Tooltip>
-          </DialogActions>
-          <Box sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center',
-            p: 2,
-            mx: { xs: 1, sm: 3, md: 5 },
-            mb: 1,
-          }}>
-          <DialogContent
-            sx = {{
-              display: "flex",
-              flexDirection: "column",
-              gap: 2,
-              mt: 1,
-              width: {
-                xs: 250,
-                sm: 300,
-                md: 400,
-                lg: 500
-              },
-            }}>
-            <Box sx={{
-              display: "flex",
-              width: '100%',
-              flexDirection: 'column',
-              overflow: 'auto',
-              justifyContent: "center",
-              gap: 1,
-              
-              '& .MuiTextField-root': {
-                  userSelect: edit === true ? 'auto' : 'none',
-                },
-            }}>
-              {isEditing && error && (
-                <ErrorAlert
-                  message={error}
-                />
-              )}
-              <SectionHeader icon={<PersonIcon fontSize="small" sx={{ opacity: 0.6 }} />}>
-                Personal Details
-              </SectionHeader>
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-                
-              }}>
-                <TextField
-                  disabled={!edit}
-                  label="First Name"
-                  name="first_name"
-                  required
-                  value={!edit && !form.first_name ? 'Not provided' : form.first_name}
-                  onChange={handleChange}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                  slotProps={{
-                    inputLabel: {
-                      shrink: true,
-                    },
-                  }}
-                />
+      </Dialog>
+      <Dialog sx={{position: "absolute"}} open={openAddContact} onClose={handleCloseAddContact} PaperProps={{ sx: { borderRadius: 3, minWidth: 340, boxShadow: '0 20px 40px rgba(0,0,0,0.18)' } }}>
+        <DialogTitle sx={{fontWeight: 700}}>
+          Move to Qualified?
+        </DialogTitle>  
 
-                <TextField
-                  disabled={!edit}
-                  label="Last Name"
-                  name="last_name"
-                  value={!edit && !form.last_name ? 'Not provided' : form.last_name}
-                  onChange={handleChange}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                  slotProps={{
-                    inputLabel: {
-                      shrink: true,
-                    },
-                  }}
-                />
-              </Box>
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-              }}>
-                <TextField
-                  select
-                  disabled={!edit}
-                  label="Suffix"
-                  name="suffix"
-                  onChange={handleChange}
-                  value={!edit && !form.suffix ? 'None' : form.suffix}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                  slotProps={{
-                    inputLabel: {
-                      shrink: true,
-                    },
-                    select: {
-                      MenuProps: {
-                        PaperProps: {
-                          sx: {
-                            maxHeight: 250,
-                          },
-                        },
-                      },
-                    },
-                  }}
-                >
-                {SUFFIXES.map((suffix) => (
-                    <MenuItem key={suffix} value={suffix}>
-                      {suffix}
-                    </MenuItem>
-                  ))}
-                </TextField>
-
-                <TextField
-                  disabled={!edit}
-                  type="tel"
-                  label="Phone"
-                  name="phone"
-                  value={!edit && !form.phone ? 'Not provided' : form.phone}
-                  onChange={handleChange}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                  slotProps={{
-                    inputLabel: {
-                      shrink: true,
-                    },
-                  }}
-                />
-              </Box>
-              
-              <TextField
-                disabled={!edit}
-                label="Email"
-                name="email"
-                value={!edit && !form.email ? 'Not provided' : form.email}
-                onChange={handleChange}
-                size="small"
-                sx={fieldSx}
-                slotProps={{
-                  inputLabel: {
-                    shrink: true,
-                  },
-                }}
-              />
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-              }}>
-                <TextField
-                  select
-                  disabled={!edit}
-                  label="Gender"
-                  name="gender"   
-                  onChange={handleChange}
-                  value={form.gender }
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                  slotProps={{
-                    inputLabel: {
-                      shrink: true,
-                    },
-                  }}
-                >
-                {GENDERS.map((gender) => (
-                  <MenuItem key={gender} value={gender}>
-                    {gender}
-                  </MenuItem>
-                ))}
-                </TextField>
-                <TextField
-                  disabled={!edit}
-                  label="Date of Birth"
-                  name="birth_date"
-                  type="date"
-                  value={form.birth_date}
-                  onChange={handleChange}
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    '& input' : {
-                      colorScheme: themeMode === 'dark' ? 'dark' : 'light', 
-                    },
-                    ...fieldSx,
-                  }}
-                />
-              </Box>
-              <SectionHeader icon={<WorkIcon fontSize="small" sx={{ opacity: 0.6 }} />}>
-                Professional Details
-              </SectionHeader>
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-              }}>
-                <Autocomplete
-                  freeSolo
-                  disabled={!edit}
-                  sx={{ width: '50%',
-                    '& .MuiOutlinedInput-root': {
-                      height: 28 
-                    },
-                    }}
-                  options={DEPARTMENTS}
-                  value={!edit && !form.department ? 'Not provided' : form.department}
-                  onChange={(_, value) => {
-                    setForm(prev => ({
-                      ...prev,
-                      department: value ?? '',
-                    }));
-                  }}
-                  onInputChange={(_, value) => {
-                    setForm(prev => ({
-                      ...prev,
-                      department: value,
-                    }));
-                  }}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      slotProps={{ inputLabel: { shrink: true } }}
-                      label="Department"
-                      size="small"
-                      sx={fieldSx}
-                    />
-                  )}
-                />
-                <Autocomplete
-                  freeSolo
-                  disabled={!edit}
-                  sx={{
-                    width: '50%',
-                    '& .MuiOutlinedInput-root': {
-                      height: 28 
-                    },
-                  }}
-                  options={INDUSTRIES}
-                  value={!edit && !form.industry ? 'Not provided' : form.industry}
-                  onChange={(_, value) => {
-                    setForm(prev => ({
-                      ...prev,
-                      industry: value ?? '',
-                    }));
-                  }}
-                  onInputChange={(_, value) => {
-                    setForm(prev => ({
-                      ...prev,
-                      industry: value,
-                    }));
-                  }}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      slotProps={{ inputLabel: { shrink: true } }}
-                      label="Industry"
-                      size="small"
-                      sx={fieldSx}
-                    />
-                  )}
-                />
-              </Box>
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-              }}>
-                
-                <TextField
-                  disabled={!edit}
-                  label="Company"
-                  name="company_name"
-                  value={!edit && !form.company_name ? 'Not provided' : form.company_name}
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  onChange={handleChange}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-              />
-                <TextField
-                  disabled={!edit}
-                  label="Position"
-                  name="position"
-                  value={!edit && !form.position ? 'Not provided' : form.position}
-                  onChange={handleChange}
-                  size="small"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                />
-              </Box>
-              <TextField
-                  disabled={!edit}
-                  label="Website Url"
-                  name="website"
-                  value={!edit && !form.website ? 'Not provided' : form.website}
-                  onChange={handleChange}
-                  size="small"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{
-                    width: '100%',
-                    ...fieldSx,
-                  }}
-                />
-              <SectionHeader icon={<ShareIcon fontSize="small" sx={{ opacity: 0.6 }} />}>
-                Social and Messaging Accounts
-              </SectionHeader>
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-              }}>
-                <TextField
-                  disabled={!edit}
-                  label="Facebook"
-                  name="facebook"
-                  value={!edit && !form.facebook ? 'Not provided' : form.facebook}
-                  onChange={handleChange}
-                  size="small"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                />
-                <TextField
-                  disabled={!edit}
-                  label="X/ Twitter"
-                  name="x"
-                  value={!edit && !form.x ? 'Not provided' : form.x}
-                  onChange={handleChange}
-                  size="small"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                />
-              </Box>
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-              }}>
-                <TextField
-                  disabled={!edit}
-                  label="Instagram"
-                  name="instagram"
-                  value={!edit && !form.instagram ? 'Not provided' : form.instagram}
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  onChange={handleChange}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-              />
-                <TextField
-                  disabled={!edit}
-                  label="Whatsapp"
-                  name="whatsapp"
-                  value={!edit && !form.whatsapp ? 'Not provided' : form.whatsapp}
-                  onChange={handleChange}
-                  size="small"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                />
-              </Box>
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-              }}>
-                <TextField
-                  disabled={!edit}
-                  label="Tiktok"
-                  name="tiktok"
-                  value={!edit && !form.tiktok ? 'Not provided' : form.tiktok}
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  onChange={handleChange}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-              />
-                <TextField
-                  disabled={!edit}
-                  label="Telegram"
-                  name="telegram"
-                  value={!edit && !form.telegram ? 'Not provided' : form.telegram}
-                  onChange={handleChange}
-                  size="small"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                />
-              </Box>
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-              }}>
-                <TextField
-                  disabled={!edit}
-                  label="Linkedin"
-                  name="linkedin"
-                  value={!edit && !form.linkedin ? 'Not provided' : form.linkedin}
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  onChange={handleChange}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-              />
-                <TextField
-                  disabled={!edit}
-                  label="Viber"
-                  name="viber"
-                  value={!edit && !form.viber ? 'Not provided' : form.viber}
-                  onChange={handleChange}
-                  size="small"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                />
-              </Box>
-              <SectionHeader icon={<NotesIcon fontSize="small" sx={{ opacity: 0.6 }} />}>
-                Additional Details
-              </SectionHeader>
-              <TextField
-                disabled={!edit}
-                  label="Title"
-                  value={form.title}
-                  name="title"
-                  required
-                  onChange={handleChange}
-                  size="small"
-                  fullWidth
-                  rows={3}
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={fieldSx}
-                />
-              <Box sx={{
-                display: "flex",
-                width: '100%',
-                justifyContent: "space-between",
-                gap: 1,
-              }}>
-                <TextField
-                  select
-                  disabled={!edit}
-                  label="Source"
-                  name="source"
-                  value={form.source}
-                  onChange={handleChange}
-                  size="small"
-                  sx={{
-                    width: '50%',
-                    ...fieldSx,
-                  }}
-                  slotProps={{
-                    inputLabel: { shrink: true },
-                    select: {
-                      MenuProps: {
-                        PaperProps: {
-                          sx: {
-                            maxHeight: 250,
-                          },
-                        },
-                      },
-                    },
-                  }}
-                >
-                  {SOURCES.map((source) => (
-                    <MenuItem key={source} value={source}>
-                      {source}
-                    </MenuItem>
-                  ))}
-                </TextField>
-                <TextField
-                  select
-                  disabled={!edit}
-                  label="Preferred Time"
-                  name="preferred_contact_time"
-                  onChange={handleChange}
-                  value={form.preferred_contact_time}
-                  size="small"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{
-                    width: '25%',
-                    ...fieldSx,
-                  }}
-                >
-                  {PREFERRED_CONTACT_TIMES.map((time) => (
-                    <MenuItem key={time} value={time}>
-                      {time}
-                    </MenuItem>
-                  ))}
-                </TextField>
-                <TextField
-                  select
-                  disabled={!edit}
-                  label="Priority"
-                  name="priority"
-                  onChange={handleChange}
-                  value={form.priority}
-                  size="small"
-                  slotProps={{ inputLabel: { shrink: true } }}
-                  sx={{
-                    width: '25%',
-                    ...fieldSx,
-                  }}
-                >
-                  {PRIORITIES.map((prio) => (
-                    <MenuItem key={prio} value={prio}>
-                      {prio}
-                    </MenuItem>
-                  ))}
-                </TextField>
-              </Box>
-              <TextField
-                label="Notes"
-                name="notes"
-                required
-                disabled={!edit}
-                value={form.notes}
-                onChange={handleChange}
-                size="small"
-                multiline
-                rows={3}
-                slotProps={{ inputLabel: { shrink: true } }}
-                sx={fieldSx}
-              />    
-          </Box > 
+        <DialogContent
+          sx = {{
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            mt: 1,
+            maxWidth: 600,
+          }}
+          >
+            Moving this to Qualified will automatically add it as a Contact.
           </DialogContent>
-          <DialogActions sx={{ display: edit === true ? 'flex' : 'none', px: 3, pb: 2 }}>
-            <Button onClick={handleNotEditable} sx={{ textTransform: 'none', borderRadius: 2 }}>
+          <DialogActions sx={{ px: 3, pb: 2 }}>
+            <Button sx={{ textTransform: 'none', borderRadius: 2 }} onClick={() => {
+                if (!dropResult) return;
+                handleCloseAddContact(dropResult);
+              }}>
               Cancel
             </Button>
             <Button 
@@ -1830,311 +1089,232 @@ const handleConfirmCloseLead = async () => {
                 '&:hover': { transform: 'translateY(-1px)' },
               }}
               onClick={() => {
-                handleOpenEditConfirmation();
+                if (!dropResult) return;
+                handleAddContact(dropResult);
               }}
-              >
-              Submit
-            </Button>
-          </DialogActions>
-          </Box>
-        </Dialog>
-        <Dialog sx={{position: "absolute"}} open={openAddContact} onClose={handleCloseAddContact} PaperProps={{ sx: { borderRadius: 3, minWidth: 340, boxShadow: '0 20px 40px rgba(0,0,0,0.18)' } }}>
-          <DialogTitle sx={{fontWeight: 700}}>
-            Move to Qualified?
-          </DialogTitle>  
-
-          <DialogContent
-            sx = {{
-              display: "flex",
-              flexDirection: "column",
-              gap: 2,
-              mt: 1,
-              maxWidth: 600,
-            }}
             >
-              Moving this to Qualified will automatically add it as a Contact.
-            </DialogContent>
-            <DialogActions sx={{ px: 3, pb: 2 }}>
-              <Button sx={{ textTransform: 'none', borderRadius: 2 }} onClick={() => {
-                  if (!dropResult) return;
-                  handleCloseAddContact(dropResult);
-                }}>
-                Cancel
-              </Button>
-              <Button 
-                variant="contained"
-                disableElevation
-                sx={{
-                  textTransform: 'none',
-                  borderRadius: 2,
-                  transition: 'transform 0.15s ease',
-                  '&:hover': { transform: 'translateY(-1px)' },
-                }}
-                onClick={() => {
-                  if (!dropResult) return;
-                  handleAddContact(dropResult);
-                }}
-              >
-                Proceed
-              </Button>
-          </DialogActions>
-        </Dialog>
-        <Dialog
-          sx={{ position: "absolute" }}
-          open={openCloseConfirmation}
-          onClose={handleCloseCloseConfirmation}
-          PaperProps={{
-            sx: {
-              borderRadius: 3,
-              minWidth: 340,
-              boxShadow: '0 20px 40px rgba(0,0,0,0.18)',
-            },
+              Proceed
+            </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        sx={{ position: "absolute" }}
+        open={openCloseConfirmation}
+        onClose={handleCloseCloseConfirmation}
+        PaperProps={{
+          sx: {
+            borderRadius: 3,
+            minWidth: 340,
+            boxShadow: '0 20px 40px rgba(0,0,0,0.18)',
+          },
+        }}
+      >
+        <DialogTitle sx={{ fontWeight: 700 }}>
+          Close this lead?
+        </DialogTitle>
+
+        <DialogContent
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            mt: 1,
+            maxWidth: 600,
           }}
         >
-          <DialogTitle sx={{ fontWeight: 700 }}>
-            Close this lead?
-          </DialogTitle>
+          Are you sure you want to mark this lead as Closed?
+          This action indicates that the lead was lost and cannot
+          be moved back to an earlier stage.
+        </DialogContent>
 
-          <DialogContent
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 2,
-              mt: 1,
-              maxWidth: 600,
-            }}
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button
+            sx={{ textTransform: "none", borderRadius: 2 }}
+            onClick={handleCloseCloseConfirmation}
           >
-            Are you sure you want to mark this lead as Closed?
-            This action indicates that the lead was lost and cannot
-            be moved back to an earlier stage.
+            Cancel
+          </Button>
+
+          <Button
+            variant="contained"
+            color="error"
+            disableElevation
+            sx={{
+              textTransform: "none",
+              borderRadius: 2,
+              transition: 'transform 0.15s ease',
+              '&:hover': { transform: 'translateY(-1px)' },
+            }}
+            onClick={handleConfirmCloseLead}
+          >
+            Yes, close lead
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog sx={{position: "absolute"}} open={openInvalid} onClose={handleCloseInvalid} PaperProps={{ sx: { borderRadius: 3, minWidth: 340, boxShadow: '0 20px 40px rgba(0,0,0,0.18)' } }}>
+        <DialogTitle sx={{fontWeight: 700}}>
+          Unable to update as Qualified
+        </DialogTitle>  
+
+        <DialogContent
+          sx = {{
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            mt: 1,
+            maxWidth: 600,
+          }}
+          >
+            Please update the lead's contact details first before moving to Qualified (email or phone).
           </DialogContent>
-
           <DialogActions sx={{ px: 3, pb: 2 }}>
-            <Button
-              sx={{ textTransform: "none", borderRadius: 2 }}
-              onClick={handleCloseCloseConfirmation}
-            >
-              Cancel
-            </Button>
-
-            <Button
+            <Button 
               variant="contained"
-              color="error"
               disableElevation
               sx={{
-                textTransform: "none",
+                textTransform: 'none',
                 borderRadius: 2,
                 transition: 'transform 0.15s ease',
                 '&:hover': { transform: 'translateY(-1px)' },
               }}
-              onClick={handleConfirmCloseLead}
+              onClick={() => {
+                handleCloseInvalid();
+              }}
             >
-              Yes, close lead
+              OK
             </Button>
-          </DialogActions>
-        </Dialog>
-        <Dialog sx={{position: "absolute"}} open={openInvalid} onClose={handleCloseInvalid} PaperProps={{ sx: { borderRadius: 3, minWidth: 340, boxShadow: '0 20px 40px rgba(0,0,0,0.18)' } }}>
-          <DialogTitle sx={{fontWeight: 700}}>
-            Unable to update as Qualified
-          </DialogTitle>  
-
-          <DialogContent
-            sx = {{
-              display: "flex",
-              flexDirection: "column",
-              gap: 2,
-              mt: 1,
-              maxWidth: 600,
-            }}
-            >
-              Please update the lead's contact details first before moving to Qualified (email or phone).
-            </DialogContent>
-            <DialogActions sx={{ px: 3, pb: 2 }}>
-              <Button 
-                variant="contained"
-                disableElevation
-                sx={{
-                  textTransform: 'none',
-                  borderRadius: 2,
-                  transition: 'transform 0.15s ease',
-                  '&:hover': { transform: 'translateY(-1px)' },
-                }}
-                onClick={() => {
-                  handleCloseInvalid();
-                }}
-              >
-                OK
-              </Button>
-          </DialogActions>
-        </Dialog>
-        <Dialog sx={{position: "absolute"}} open={openEditConfirmation} onClose={handleCloseEditConfirmation} PaperProps={{ sx: { borderRadius: 3, minWidth: 340, boxShadow: '0 20px 40px rgba(0,0,0,0.18)' } }}>
-          <DialogTitle sx={{fontWeight: 700}}>
-            Confirm changes
-          </DialogTitle>  
-
-          <DialogContent
-            sx = {{
-              display: "flex",
-              flexDirection: "column",
-              gap: 2,
-              mt: 1,
-              maxWidth: 600,
-            }}
-            >
-              Are you sure you want to edit this lead?
-            </DialogContent>
-            <DialogActions sx={{ px: 3, pb: 2 }}>
-              <Button sx={{ textTransform: 'none', borderRadius: 2 }} onClick={handleCloseEditConfirmation}>
-                Cancel
-              </Button>
-              <Button 
-                variant="contained"
-                disableElevation
-                sx={{
-                  textTransform: 'none',
-                  borderRadius: 2,
-                  transition: 'transform 0.15s ease',
-                  '&:hover': { transform: 'translateY(-1px)' },
-                }}
-                onClick={() => {
-                  handleCloseEditConfirmation();
-                  handleEdit();
-                }}
-              >
-                Yes
-              </Button>
-          </DialogActions>
-        </Dialog>
-        <Popover
-          disableRestoreFocus
-          sx={{ pointerEvents: 'none' }}
-          open={Boolean(anchorEl)}
-          anchorEl={anchorEl}
-          onClose={handleMouseLeave}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'left',
-          }}
-        >
-          <Card sx={{ p: 2, width: 340,
-                borderRadius: 3,
-                whiteSpace: 'normal',
-                overflowWrap: 'break-word',
-                boxShadow: '0 16px 32px rgba(0,0,0,0.14)',
-              }}>
-            <Stack alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
-              <Avatar sx={{ width: 64, height: 64, bgcolor: 'action.hover' }}>
-                <PersonIcon sx={{ fontSize: 32, opacity: 0.7, color: 'text.secondary' }}/>
-              </Avatar>
-              <Box sx={{ textAlign: 'center' }}>
-                <Typography variant="subtitle1" fontWeight={700} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.75 }}>
-                  {formatName(hoveredLead?.first_name, hoveredLead?.last_name)} {hoveredLead?.suffix}
-                  {hoveredLead && <PriorityBadge priority={hoveredLead.priority} />}
-                </Typography>
-              </Box>
-            </Stack>
+        </DialogActions>
+      </Dialog>
+      <Popover
+        disableRestoreFocus
+        sx={{ pointerEvents: 'none' }}
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={handleMouseLeave}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+      >
+        <Card sx={{ p: 2, width: 340,
+              borderRadius: 3,
+              whiteSpace: 'normal',
+              overflowWrap: 'break-word',
+              boxShadow: '0 16px 32px rgba(0,0,0,0.14)',
+            }}>
+          <Stack alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+            <Avatar sx={{ width: 64, height: 64, bgcolor: 'action.hover' }}>
+              <PersonIcon sx={{ fontSize: 32, opacity: 0.7, color: 'text.secondary' }}/>
+            </Avatar>
+            <Box sx={{ textAlign: 'center' }}>
+              <Typography variant="subtitle1" fontWeight={700} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.75 }}>
+                {formatName(hoveredLead?.first_name, hoveredLead?.last_name)} {hoveredLead?.suffix}
+                {hoveredLead && <PriorityBadge priority={hoveredLead.priority} />}
+              </Typography>
+            </Box>
+          </Stack>
+          <Box sx={{
+            display: 'flex',
+            justifyContent: 'space-between'
+          }}>
             <Box sx={{
               display: 'flex',
-              justifyContent: 'space-between'
+              flexDirection: 'column',
+              gap: 0.25,
             }}>
-              <Box sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 0.25,
-              }}>
-                {hoveredLead?.email && (
-                <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                  <EmailIcon sx={{ fontSize: 14, opacity: 0.6 }} /> {hoveredLead?.email}
-                </Typography>
-                )}
-                {hoveredLead?.phone && (
-                <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                  <CallIcon sx={{ fontSize: 14, opacity: 0.6 }} /> {hoveredLead?.phone}
-                </Typography>
-                )}
-              </Box>
-              <Box sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                textAlign: 'right',
-              }}>
-                {hoveredLead?.gender !== 'Prefer not to say' && (
-                <Typography variant="body2" color="text.secondary">
-                  {hoveredLead?.gender }
-                </Typography>
-                )}
-                {hoveredLead?.birth_date && (
-                <Typography variant="body2" color="text.secondary">
-                  Age: {!hoveredLead?.birth_date
-                  ? ''
-                  : calculateAge(hoveredLead.birth_date)}
-                </Typography>
-                )}
-              </Box>
+              {hoveredLead?.email && (
+              <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <EmailIcon sx={{ fontSize: 14, opacity: 0.6 }} /> {hoveredLead?.email}
+              </Typography>
+              )}
+              {hoveredLead?.phone && (
+              <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <CallIcon sx={{ fontSize: 14, opacity: 0.6 }} /> {hoveredLead?.phone}
+              </Typography>
+              )}
             </Box>
-            <Box 
-            sx={{
+            <Box sx={{
               display: 'flex',
               flexDirection: 'column',
-              mt: hoveredLead?.email || hoveredLead?.phone ? 1 : 0,
+              textAlign: 'right',
             }}>
-              {hoveredLead?.facebook && (
-                <Typography variant="body2" color="text.secondary">
-                  Facebook: facebook.com/{hoveredLead.facebook}
-                </Typography>
+              {hoveredLead?.gender !== 'Prefer not to say' && (
+              <Typography variant="body2" color="text.secondary">
+                {hoveredLead?.gender }
+              </Typography>
               )}
-              {hoveredLead?.instagram && (
-                <Typography variant="body2" color="text.secondary">
-                  Instagram: @{hoveredLead.instagram}
-                </Typography>
-              )}
-              {hoveredLead?.tiktok && (
-                <Typography variant="body2" color="text.secondary">
-                  TikTok: @{hoveredLead.tiktok}
-                </Typography>
-              )}
-              {hoveredLead?.x && (
-                <Typography variant="body2" color="text.secondary">
-                  X/Twitter: @{hoveredLead.x}
-                </Typography>
-              )}
-              {hoveredLead?.linkedin && (
-                <Typography variant="body2" color="text.secondary">
-                  LinkedIn: linkedin.com/in/{hoveredLead.linkedin}
-                </Typography>
-              )}
-              {hoveredLead?.telegram && (
-                <Typography variant="body2" color="text.secondary">
-                  Telegram: @{hoveredLead.telegram}
-                </Typography>
-              )}
-              {hoveredLead?.whatsapp && (
-                <Typography variant="body2" color="text.secondary">
-                  WhatsApp: {hoveredLead.whatsapp}
-                </Typography>
-              )}
-              {hoveredLead?.viber && (
-                <Typography variant="body2" color="text.secondary">
-                  Viber: {hoveredLead.viber}
-                </Typography>
+              {hoveredLead?.birth_date && (
+              <Typography variant="body2" color="text.secondary">
+                Age: {!hoveredLead?.birth_date
+                ? ''
+                : calculateAge(hoveredLead.birth_date)}
+              </Typography>
               )}
             </Box>
-            <Divider sx={{mt: 2, mb: 1}}></Divider>
-            <Typography marginBottom={1} variant="body1" fontWeight={700}>
-              {hoveredLead?.title.toUpperCase()}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {hoveredLead?.notes}
-            </Typography>
-          </Card>
-        </Popover>
-        <Snackbar
-          open={openSnackbar}
-          autoHideDuration={3000}
-          onClose={() => setOpenSnackbar(false)}
-          message="This feature is coming soon!"
-          ContentProps={{ sx: { borderRadius: 2 } }}
-        />
+          </Box>
+          <Box 
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            mt: hoveredLead?.email || hoveredLead?.phone ? 1 : 0,
+          }}>
+            {hoveredLead?.facebook && (
+              <Typography variant="body2" color="text.secondary">
+                Facebook: facebook.com/{hoveredLead.facebook}
+              </Typography>
+            )}
+            {hoveredLead?.instagram && (
+              <Typography variant="body2" color="text.secondary">
+                Instagram: @{hoveredLead.instagram}
+              </Typography>
+            )}
+            {hoveredLead?.tiktok && (
+              <Typography variant="body2" color="text.secondary">
+                TikTok: @{hoveredLead.tiktok}
+              </Typography>
+            )}
+            {hoveredLead?.x && (
+              <Typography variant="body2" color="text.secondary">
+                X/Twitter: @{hoveredLead.x}
+              </Typography>
+            )}
+            {hoveredLead?.linkedin && (
+              <Typography variant="body2" color="text.secondary">
+                LinkedIn: linkedin.com/in/{hoveredLead.linkedin}
+              </Typography>
+            )}
+            {hoveredLead?.telegram && (
+              <Typography variant="body2" color="text.secondary">
+                Telegram: @{hoveredLead.telegram}
+              </Typography>
+            )}
+            {hoveredLead?.whatsapp && (
+              <Typography variant="body2" color="text.secondary">
+                WhatsApp: {hoveredLead.whatsapp}
+              </Typography>
+            )}
+            {hoveredLead?.viber && (
+              <Typography variant="body2" color="text.secondary">
+                Viber: {hoveredLead.viber}
+              </Typography>
+            )}
+          </Box>
+          <Divider sx={{mt: 2, mb: 1}}></Divider>
+          <Typography marginBottom={1} variant="body1" fontWeight={700}>
+            {hoveredLead?.title.toUpperCase()}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {hoveredLead?.notes}
+          </Typography>
+        </Card>
+      </Popover>
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={3000}
+        onClose={() => setOpenSnackbar(false)}
+        message="This feature is coming soon!"
+        ContentProps={{ sx: { borderRadius: 2 } }}
+      />
     </Box>
   );
 }

--- a/src/services/contactService.ts
+++ b/src/services/contactService.ts
@@ -4,12 +4,13 @@ import type {
   Contact,
   ContactCareer,
   ContactListItem,
+  ContactPersonal,
   ContactSocials,
-  UpdateContact,
 } from "../types/contact";
+import type { PreferredTime, Priority, Source } from "../types/global";
 
 export const fetchContactsAPI = async (): Promise<Contact[]> => {
-  const result = await apiClient("/api/contacts/show-contacts", {
+  const result = await apiClient("/api/contacts/show", {
     method: "GET",
   });
 
@@ -17,7 +18,7 @@ export const fetchContactsAPI = async (): Promise<Contact[]> => {
 };
 
 export const fetchContactsListsAPI = async (): Promise<ContactListItem[]> => {
-  const result = await apiClient("/api/contacts/show-contacts-lists", {
+  const result = await apiClient("/api/contacts/show-lists", {
     method: "GET",
   });
 
@@ -27,7 +28,7 @@ export const fetchContactsListsAPI = async (): Promise<ContactListItem[]> => {
 export const addContactAPI = async (
   contact: AddContact
 ): Promise<ContactListItem> => {
-  const result = await apiClient("/api/contacts/add-contact", {
+  const result = await apiClient("/api/contacts/add", {
     method: "POST",
     body: JSON.stringify(contact),
   });
@@ -38,7 +39,7 @@ export const addContactAPI = async (
 export const addContactFromLeadsAPI = async (
   contact: AddContact
 ): Promise<ContactListItem> => {
-  const result = await apiClient("/api/contacts/move-contact", {
+  const result = await apiClient("/api/contacts/move", {
     method: "POST",
     body: JSON.stringify(contact),
   });
@@ -46,23 +47,23 @@ export const addContactFromLeadsAPI = async (
   return result.data as ContactListItem;
 };
 
-export const updateContactAPI = async (
+export const updateContactPersonalAPI = async (
   id: string,
-  contact: UpdateContact
+  personal: ContactPersonal
 ): Promise<ContactListItem> => {
-  const result = await apiClient(`/api/contacts/update-contact/${id}`, {
+  const result = await apiClient(`/api/contacts/update/personal/${id}`, {
     method: "PATCH",
-    body: JSON.stringify(contact),
+    body: JSON.stringify(personal),
   });
 
   return result.data as ContactListItem;
 };
 
-export const updateSocialsAPI = async (
+export const updateContactSocialsAPI = async (
   id: string,
   socials: ContactSocials
 ): Promise<ContactListItem> => {
-  const result = await apiClient(`/api/contacts/update-socials/${id}`, {
+  const result = await apiClient(`/api/contacts/update/socials/${id}`, {
     method: "PATCH",
     body: JSON.stringify(socials),
   });
@@ -70,11 +71,11 @@ export const updateSocialsAPI = async (
   return result.data as ContactListItem;
 };
 
-export const updateCareerAPI = async (
+export const updateContactCareerAPI = async (
   id: string,
   career: ContactCareer
 ): Promise<ContactListItem> => {
-  const result = await apiClient(`/api/contacts/update-career/${id}`, {
+  const result = await apiClient(`/api/contacts/update/career/${id}`, {
     method: "PATCH",
     body: JSON.stringify(career),
   });
@@ -82,11 +83,64 @@ export const updateCareerAPI = async (
   return result.data as ContactListItem;
 };
 
+export const updateContactNotesAPI = async (
+  id: string,
+  notes: string
+): Promise<ContactListItem> => {
+  
+  const result = await apiClient(`/api/contacts/update/notes/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({notes}),
+  });
+  
+  return result.data as ContactListItem;
+};
+
+export const updateContactSourceAPI = async (
+  id: string,
+  source: Source
+): Promise<ContactListItem> => {
+  
+  const result = await apiClient(`/api/contacts/update/source/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({source}),
+  });
+  
+  return result.data as ContactListItem;
+};
+
+export const updateContactPriorityAPI = async (
+  id: string,
+  priority: Priority
+): Promise<ContactListItem> => {
+  
+  const result = await apiClient(`/api/contacts/update/priority/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({priority}),
+  });
+  
+  return result.data as ContactListItem;
+};
+
+export const updateContactPreferredTimeAPI = async (
+  id: string,
+  preferredTime: PreferredTime
+): Promise<ContactListItem> => {
+  
+  const result = await apiClient(`/api/contacts/update/preferred-time/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({preferredTime}),
+  });
+  
+  return result.data as ContactListItem;
+};
+
+
 
 export const deleteContactAPI = async (
   id: string
 ): Promise<string> => {
-  const result = await apiClient(`/api/contacts/delete-contact/${id}`, {
+  const result = await apiClient(`/api/contacts/delete/${id}`, {
     method: "DELETE",
   });
 
@@ -96,7 +150,7 @@ export const deleteContactAPI = async (
 export const deleteBulkContactsAPI = async (
   ids: string[]
 ): Promise<string> => {
-  const result = await apiClient(`/api/contacts/delete-contacts`, {
+  const result = await apiClient(`/api/contacts/delete/bulk`, {
     method: "DELETE",
     body: JSON.stringify({ids}),
   });

--- a/src/services/customerService.ts
+++ b/src/services/customerService.ts
@@ -25,7 +25,6 @@ export const updateCustomerNotesAPI = async (
     method: "PATCH",
     body: JSON.stringify({notes}),
   });
-
   return result.data as CustomerListItem;
 };
 

--- a/src/services/leadService.ts
+++ b/src/services/leadService.ts
@@ -39,7 +39,7 @@ export const updateLeadCareerAPI = async (
   id: string,
   career: LeadCareer
 ): Promise<LeadListItem> => {
-  const result = await apiClient(`/api/leads/update/personal/${id}`, {
+  const result = await apiClient(`/api/leads/update/career/${id}`, {
     method: "PATCH",
     body: JSON.stringify(career),
   });
@@ -51,7 +51,7 @@ export const updateLeadSocialsAPI = async (
   id: string,
   socials: LeadSocials
 ): Promise<LeadListItem> => {
-  const result = await apiClient(`/api/leads/update/personal/${id}`, {
+  const result = await apiClient(`/api/leads/update/socials/${id}`, {
     method: "PATCH",
     body: JSON.stringify(socials),
   });

--- a/src/services/leadService.ts
+++ b/src/services/leadService.ts
@@ -1,9 +1,10 @@
 import { apiClient } from "./apiClient";
-import type { AddLead,  LeadListItem, LeadStatus, UpdateLead } from "../types/lead";
+import type { AddLead, LeadCareer, LeadListItem, LeadPersonal, LeadSocials, LeadStatus} from "../types/lead";
+import type { PreferredTime, Priority, Source } from "../types/global";
 
 
 export const fetchLeadsListsAPI = async (): Promise<LeadListItem[]> => {
-  const result = await apiClient('/api/leads/show-leads-lists', {
+  const result = await apiClient('/api/leads/show-lists', {
     method: "GET",
   });
 
@@ -14,7 +15,7 @@ export const fetchLeadsListsAPI = async (): Promise<LeadListItem[]> => {
 export const addLeadAPI = async (
   lead: AddLead
 ): Promise<LeadListItem> => {
-  const result = await apiClient("/api/leads/add-lead", {
+  const result = await apiClient("/api/leads/add", {
     method: "POST",
     body: JSON.stringify(lead),
   });
@@ -22,13 +23,37 @@ export const addLeadAPI = async (
   return result.data as LeadListItem;
 };
 
-export const updateLeadAPI = async (
+export const updateLeadPersonalAPI = async (
   id: string,
-  lead: UpdateLead
+  personal: LeadPersonal
 ): Promise<LeadListItem> => {
-  const result = await apiClient(`/api/leads/update-lead/${id}`, {
+  const result = await apiClient(`/api/leads/update/personal/${id}`, {
     method: "PATCH",
-    body: JSON.stringify(lead),
+    body: JSON.stringify(personal),
+  });
+
+  return result.data as LeadListItem;
+};
+
+export const updateLeadCareerAPI = async (
+  id: string,
+  career: LeadCareer
+): Promise<LeadListItem> => {
+  const result = await apiClient(`/api/leads/update/personal/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(career),
+  });
+
+  return result.data as LeadListItem;
+};
+
+export const updateLeadSocialsAPI = async (
+  id: string,
+  socials: LeadSocials
+): Promise<LeadListItem> => {
+  const result = await apiClient(`/api/leads/update/personal/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(socials),
   });
 
   return result.data as LeadListItem;
@@ -39,7 +64,7 @@ export const updateLeadStatusAPI = async (
   status: LeadStatus
 ): Promise<LeadListItem> => {
   
-  const result = await apiClient(`/api/leads/update-lead-status/${id}`, {
+  const result = await apiClient(`/api/leads/update/status/${id}`, {
     method: "PATCH",
     body: JSON.stringify({status}),
   });
@@ -47,10 +72,65 @@ export const updateLeadStatusAPI = async (
   return result.data as LeadListItem;
 };
 
+export const updateLeadNotesAPI = async (
+  id: string,
+  notes: string
+): Promise<LeadListItem> => {
+  
+  const result = await apiClient(`/api/leads/update/notes/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({notes}),
+  });
+  
+  return result.data as LeadListItem;
+};
+
+export const updateLeadSourceAPI = async (
+  id: string,
+  source: Source
+): Promise<LeadListItem> => {
+  
+  const result = await apiClient(`/api/leads/update/source/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({source}),
+  });
+  
+  return result.data as LeadListItem;
+};
+
+export const updateLeadPriorityAPI = async (
+  id: string,
+  priority: Priority
+): Promise<LeadListItem> => {
+  
+  const result = await apiClient(`/api/leads/update/priority/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({priority}),
+  });
+  
+  return result.data as LeadListItem;
+};
+
+export const updateLeadPreferredTimeAPI = async (
+  id: string,
+  preferredTime: PreferredTime
+): Promise<LeadListItem> => {
+  
+  const result = await apiClient(`/api/leads/update/preferred-time/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({preferredTime}),
+  });
+  
+  return result.data as LeadListItem;
+};
+
+
+
+
 export const deleteLeadAPI = async (
   id: string
 ): Promise<string> => {
-  const result = await apiClient(`/api/leads/delete-lead/${id}`, {
+  const result = await apiClient(`/api/leads/delete/${id}`, {
     method: "DELETE",
   });
 

--- a/src/store/contactsSlice.ts
+++ b/src/store/contactsSlice.ts
@@ -1,15 +1,20 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import type { AddContact, ContactCareer, ContactSocials, ContactsState, UpdateContact } from "../types/contact"
+import type { AddContact, ContactCareer, ContactPersonal, ContactSocials, ContactsState } from "../types/contact"
 import {
   addContactAPI,
   addContactFromLeadsAPI,
-  updateContactAPI,
   deleteContactAPI,
   deleteBulkContactsAPI,
-  updateSocialsAPI,
-  updateCareerAPI,
   fetchContactsListsAPI,
+  updateContactPersonalAPI,
+  updateContactSocialsAPI,
+  updateContactCareerAPI,
+  updateContactNotesAPI,
+  updateContactSourceAPI,
+  updateContactPriorityAPI,
+  updateContactPreferredTimeAPI,
 } from '../services/contactService';
+import type { PreferredTime, Priority, Source } from "../types/global";
 
 
 const initialState: ContactsState = {
@@ -20,7 +25,7 @@ const initialState: ContactsState = {
 };
 
 export const fetchContactsLists = createAsyncThunk(
-  'contacts/show-contacts-lists',
+  'contacts/show-lists',
   async (_, thunkAPI) => {
     try {
       return await fetchContactsListsAPI();
@@ -37,7 +42,7 @@ export const fetchContactsLists = createAsyncThunk(
 );
 
 export const addContact = createAsyncThunk(
-  'contacts/add-contact',
+  'contacts/add',
   async (
       contact: AddContact, thunkAPI) => {
     try {
@@ -72,14 +77,14 @@ export const addContactFromLeads = createAsyncThunk(
   }
 );
 
-export const updateContact = createAsyncThunk(
-  'contacts/update-contact',
-  async ({id, contact}:{
+export const updateContactPersonal = createAsyncThunk(
+  'contacts/update/personal',
+  async ({id, personal}:{
       id: string;
-      contact: UpdateContact
+      personal: ContactPersonal
     },thunkAPI) => {
     try {
-      return await updateContactAPI( id, contact);
+      return await updateContactPersonalAPI( id, personal);
     } catch (err) {
       if (err instanceof Error) {
         return thunkAPI.rejectWithValue(err.message);
@@ -92,14 +97,14 @@ export const updateContact = createAsyncThunk(
   }
 );
 
-export const updateSocials = createAsyncThunk(
-  'contacts/update-socials',
+export const updateContactSocials = createAsyncThunk(
+  'contacts/update/socials',
   async ({id, socials}:{
       id: string;
       socials: ContactSocials
     },thunkAPI) => {
     try {
-      return await updateSocialsAPI( id, socials);
+      return await updateContactSocialsAPI( id, socials);
     } catch (err) {
       if (err instanceof Error) {
         return thunkAPI.rejectWithValue(err.message);
@@ -112,14 +117,86 @@ export const updateSocials = createAsyncThunk(
   }
 );
 
-export const updateCareer = createAsyncThunk(
-  'contacts/update-career',
+export const updateContactCareer = createAsyncThunk(
+  'contacts/update/career',
   async ({id, career}:{
       id: string;
       career: ContactCareer
     },thunkAPI) => {
     try {
-      return await updateCareerAPI( id, career);
+      return await updateContactCareerAPI( id, career);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
+export const updateContactNotes = createAsyncThunk(
+  'contacts/update/notes',
+  async ({ id, notes }:{ id: string, notes: string}
+    ,thunkAPI) => {
+    try {
+      return await updateContactNotesAPI( id, notes);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
+export const updateContactSource = createAsyncThunk(
+  'contacts/update/source',
+  async ({ id, source }:{ id: string, source: Source}
+    ,thunkAPI) => {
+    try {
+      return await updateContactSourceAPI( id, source);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
+export const updateContactPriority = createAsyncThunk(
+  'contacts/update/priority',
+  async ({ id, priority }:{ id: string, priority: Priority}
+    ,thunkAPI) => {
+    try {
+      return await updateContactPriorityAPI( id, priority);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
+export const updateContactPreferredTime = createAsyncThunk(
+  'contacts/update/preferred-time',
+  async ({ id, preferredTime }:{ id: string, preferredTime: PreferredTime}
+    ,thunkAPI) => {
+    try {
+      return await updateContactPreferredTimeAPI( id, preferredTime);
     } catch (err) {
       if (err instanceof Error) {
         return thunkAPI.rejectWithValue(err.message);
@@ -133,7 +210,7 @@ export const updateCareer = createAsyncThunk(
 );
 
 export const deleteContact = createAsyncThunk(
-  'contacts/delete-contact',
+  'contacts/delete',
   async (id: string, thunkAPI) => {
     try {
       return await deleteContactAPI(id);
@@ -150,7 +227,7 @@ export const deleteContact = createAsyncThunk(
 );
 
 export const deleteBulkContacts = createAsyncThunk(
-  'contacts/delete-contacts',
+  'contacts/delete/bulk',
   async (ids: string[], thunkAPI) => {
     try {
       return await deleteBulkContactsAPI(ids);
@@ -227,55 +304,119 @@ const contactsSlice = createSlice({
     });
 
 
-    builder.addCase(updateContact.pending, (state) => {
+    builder.addCase(updateContactPersonal.pending, (state) => {
       state.error = null;
     });
 
-    builder.addCase(updateContact.fulfilled, (state, action) => {
+    builder.addCase(updateContactPersonal.fulfilled, (state, action) => {
       const index = state.items.findIndex(c => c.id === action.payload.id);
       if(index !== -1) state.items[index] = action.payload;
       state.loading = false;
     });
 
-    builder.addCase(updateContact.rejected, (state, action) => {
+    builder.addCase(updateContactPersonal.rejected, (state, action) => {
       state.error = action.payload as string
       state.loading = false;
     });
 
 
 
-    builder.addCase(updateSocials.pending, (state) => {
+    builder.addCase(updateContactSocials.pending, (state) => {
       state.error = null;
     });
 
-    builder.addCase(updateSocials.fulfilled, (state, action) => {
+    builder.addCase(updateContactSocials.fulfilled, (state, action) => {
       const index = state.items.findIndex(c => c.id === action.payload.id);
       if(index !== -1) state.items[index] = action.payload;
       state.loading = false;
     });
 
-    builder.addCase(updateSocials.rejected, (state, action) => {
+    builder.addCase(updateContactSocials.rejected, (state, action) => {
       state.error = action.payload as string
       state.loading = false;
     });
 
 
 
-    builder.addCase(updateCareer.pending, (state) => {
+    builder.addCase(updateContactCareer.pending, (state) => {
       state.error = null;
     });
 
-    builder.addCase(updateCareer.fulfilled, (state, action) => {
+    builder.addCase(updateContactCareer.fulfilled, (state, action) => {
       const index = state.items.findIndex(c => c.id === action.payload.id);
       if(index !== -1) state.items[index] = action.payload;
       state.loading = false;
     });
 
-    builder.addCase(updateCareer.rejected, (state, action) => {
+    builder.addCase(updateContactCareer.rejected, (state, action) => {
       state.error = action.payload as string
       state.loading = false;
     });
 
+
+
+    builder.addCase(updateContactNotes.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateContactNotes.fulfilled, (state, action) => {
+      const index = state.items.findIndex(c => c.id === action.payload.id);
+      if (index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateContactNotes.rejected, (state, action) => {
+      state.error = action.payload as string;
+      state.loading = false;
+    });
+
+
+    builder.addCase(updateContactSource.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateContactSource.fulfilled, (state, action) => {
+      const index = state.items.findIndex(c => c.id === action.payload.id);
+      if (index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateContactSource.rejected, (state, action) => {
+      state.error = action.payload as string;
+      state.loading = false;
+    });
+
+
+    builder.addCase(updateContactPriority.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateContactPriority.fulfilled, (state, action) => {
+      const index = state.items.findIndex(c => c.id === action.payload.id);
+      if (index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateContactPriority.rejected, (state, action) => {
+      state.error = action.payload as string;
+      state.loading = false;
+    });
+
+
+    builder.addCase(updateContactPreferredTime.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateContactPreferredTime.fulfilled, (state, action) => {
+      const index = state.items.findIndex(c => c.id === action.payload.id);
+      if (index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateContactPreferredTime.rejected, (state, action) => {
+      state.error = action.payload as string;
+      state.loading = false;
+    });
 
 
     builder.addCase(deleteContact.pending, (state) => {

--- a/src/store/leadsSlice.ts
+++ b/src/store/leadsSlice.ts
@@ -1,12 +1,19 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import type  { AddLead, LeadsState, LeadStatus,UpdateLead } from "../types/lead"
+import type  { AddLead, LeadCareer, LeadPersonal, LeadSocials, LeadsState, LeadStatus } from "../types/lead"
 import {
   addLeadAPI,
-  updateLeadAPI,
+  updateLeadPersonalAPI,
   deleteLeadAPI,
   updateLeadStatusAPI,
   fetchLeadsListsAPI,
+  updateLeadCareerAPI,
+  updateLeadSocialsAPI,
+  updateLeadNotesAPI,
+  updateLeadSourceAPI,
+  updateLeadPriorityAPI,
+  updateLeadPreferredTimeAPI,
 } from '../services/leadService';
+import type { PreferredTime, Priority, Source } from "../types/global";
 
 
 const initialState: LeadsState = {
@@ -18,7 +25,7 @@ const initialState: LeadsState = {
 
 
 export const fetchLeadsLists = createAsyncThunk(
-  'leads/show-leads-lists',
+  'leads/show-lists',
   async (_, thunkAPI) => {
     try {
       return await fetchLeadsListsAPI();
@@ -35,7 +42,7 @@ export const fetchLeadsLists = createAsyncThunk(
 );
 
 export const addLead = createAsyncThunk(
-  'leads/add-lead',
+  'leads/add',
   async (
       lead: AddLead, 
       thunkAPI) => {
@@ -54,14 +61,54 @@ export const addLead = createAsyncThunk(
 );
 
 
-export const updateLead = createAsyncThunk(
-  'leads/update-lead',
-  async ({id, lead}:{
+export const updateLeadPersonal = createAsyncThunk(
+  'leads/update/personal',
+  async ({id, personal}:{
       id: string;
-      lead: UpdateLead
+      personal: LeadPersonal
     },thunkAPI) => {
     try {
-      return await updateLeadAPI( id, lead);
+      return await updateLeadPersonalAPI( id, personal);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
+export const updateLeadCareer = createAsyncThunk(
+  'leads/update/career',
+  async ({id, career}:{
+      id: string;
+      career: LeadCareer
+    },thunkAPI) => {
+    try {
+      return await updateLeadCareerAPI( id, career);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
+export const updateLeadSocials = createAsyncThunk(
+  'leads/update/socials',
+  async ({id, socials}:{
+      id: string;
+      socials: LeadSocials
+    },thunkAPI) => {
+    try {
+      return await updateLeadSocialsAPI( id, socials);
     } catch (err) {
       if (err instanceof Error) {
         return thunkAPI.rejectWithValue(err.message);
@@ -75,7 +122,7 @@ export const updateLead = createAsyncThunk(
 );
 
 export const updateLeadStatus = createAsyncThunk(
-  'leads/update-lead-status',
+  'leads/update/status',
   async ({ id, status }:{ id: string, status: LeadStatus}
     ,thunkAPI) => {
     try {
@@ -92,8 +139,80 @@ export const updateLeadStatus = createAsyncThunk(
   }
 );
 
+export const updateLeadNotes = createAsyncThunk(
+  'leads/update/notes',
+  async ({ id, notes }:{ id: string, notes: string}
+    ,thunkAPI) => {
+    try {
+      return await updateLeadNotesAPI( id, notes);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
+export const updateLeadSource = createAsyncThunk(
+  'leads/update/source',
+  async ({ id, source }:{ id: string, source: Source}
+    ,thunkAPI) => {
+    try {
+      return await updateLeadSourceAPI( id, source);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
+export const updateLeadPriority = createAsyncThunk(
+  'leads/update/priority',
+  async ({ id, priority }:{ id: string, priority: Priority}
+    ,thunkAPI) => {
+    try {
+      return await updateLeadPriorityAPI( id, priority);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
+export const updateLeadPreferredTime = createAsyncThunk(
+  'leads/update/preferred-time',
+  async ({ id, preferredTime }:{ id: string, preferredTime: PreferredTime}
+    ,thunkAPI) => {
+    try {
+      return await updateLeadPreferredTimeAPI( id, preferredTime);
+    } catch (err) {
+      if (err instanceof Error) {
+        return thunkAPI.rejectWithValue(err.message);
+      }
+      return thunkAPI
+        .rejectWithValue(
+          'Something went wrong'
+        );
+    }
+  }
+);
+
 export const deleteLead = createAsyncThunk(
-  'leads/delete-lead',
+  'leads/delete',
   async (id: string, thunkAPI) => {
     try {
       return await deleteLeadAPI(id);
@@ -161,17 +280,47 @@ const leadSlice = createSlice({
     });
     
 
-    builder.addCase(updateLead.pending, (state) => {
+    builder.addCase(updateLeadPersonal.pending, (state) => {
       state.error = null;
     });
 
-    builder.addCase(updateLead.fulfilled, (state, action) => {
+    builder.addCase(updateLeadPersonal.fulfilled, (state, action) => {
       const index = state.items.findIndex(l => l.id === action.payload.id);
       if(index !== -1) state.items[index] = action.payload;
       state.loading = false;
     });
 
-    builder.addCase(updateLead.rejected, (state, action) => {
+    builder.addCase(updateLeadPersonal.rejected, (state, action) => {
+      state.error = action.payload as string
+      state.loading = false;
+    });
+
+    builder.addCase(updateLeadSocials.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateLeadSocials.fulfilled, (state, action) => {
+      const index = state.items.findIndex(l => l.id === action.payload.id);
+      if(index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateLeadSocials.rejected, (state, action) => {
+      state.error = action.payload as string
+      state.loading = false;
+    });
+
+    builder.addCase(updateLeadCareer.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateLeadCareer.fulfilled, (state, action) => {
+      const index = state.items.findIndex(l => l.id === action.payload.id);
+      if(index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateLeadCareer.rejected, (state, action) => {
       state.error = action.payload as string
       state.loading = false;
     });
@@ -189,6 +338,70 @@ const leadSlice = createSlice({
     });
 
     builder.addCase(updateLeadStatus.rejected, (state, action) => {
+      state.error = action.payload as string
+      state.loading = false;
+    });
+
+    
+    builder.addCase(updateLeadNotes.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateLeadNotes.fulfilled, (state, action) => {
+      const index = state.items.findIndex(l => l.id === action.payload.id);
+      if(index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateLeadNotes.rejected, (state, action) => {
+      state.error = action.payload as string
+      state.loading = false;
+    });
+
+
+    builder.addCase(updateLeadSource.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateLeadSource.fulfilled, (state, action) => {
+      const index = state.items.findIndex(l => l.id === action.payload.id);
+      if(index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateLeadSource.rejected, (state, action) => {
+      state.error = action.payload as string
+      state.loading = false;
+    });
+
+
+    builder.addCase(updateLeadPriority.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateLeadPriority.fulfilled, (state, action) => {
+      const index = state.items.findIndex(l => l.id === action.payload.id);
+      if(index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateLeadPriority.rejected, (state, action) => {
+      state.error = action.payload as string
+      state.loading = false;
+    });
+
+
+    builder.addCase(updateLeadPreferredTime.pending, (state) => {
+      state.error = null;
+    });
+
+    builder.addCase(updateLeadPreferredTime.fulfilled, (state, action) => {
+      const index = state.items.findIndex(l => l.id === action.payload.id);
+      if(index !== -1) state.items[index] = action.payload;
+      state.loading = false;
+    });
+
+    builder.addCase(updateLeadPreferredTime.rejected, (state, action) => {
       state.error = action.payload as string
       state.loading = false;
     });

--- a/src/types/contact.ts
+++ b/src/types/contact.ts
@@ -94,7 +94,7 @@ export interface AddContact {
   viber?: string;
 }
 
-export interface UpdateContact {
+export interface ContactPersonal {
   first_name?: string;
   last_name?: string;
   suffix?: Suffix;
@@ -102,11 +102,6 @@ export interface UpdateContact {
   birth_date?: string | null;
   email?: string;
   phone?: string;
-  source?: Source;
-  status: ContactStatus;
-  priority: Priority;
-  notes?: string;
-  preferred_contact_time: PreferredTime;
 }
 
 export interface ContactCareer {

--- a/src/types/lead.ts
+++ b/src/types/lead.ts
@@ -94,25 +94,25 @@ export interface AddLead {
   telegram?: string;
   viber?: string;
 }
-export interface UpdateLead {
-  id: string;
-  title: string;
-  source: Source;
-  first_name: string;
-  last_name: string;
+export interface LeadPersonal {
+  first_name?: string;
+  last_name?: string;
   suffix?: Suffix;
-  gender: Gender;
+  gender?: Gender;
   birth_date?: string | null;
-  email?: string | null;
-  phone?: string | null;
+  email?: string;
+  phone?: string;
+}
+
+export interface LeadCareer {
   company_name?: string;
-  industry?: string;
   position?: string;  
   department?: string;
+  industry?: string;
   website?: string;
-  priority: Priority;
-  notes?: string;
-  preferred_contact_time: PreferredTime;
+}
+
+export interface LeadSocials {
   linkedin?: string;
   facebook?: string;
   instagram?: string;


### PR DESCRIPTION
## What changed

- Added a dedicated Lead Detail Page
- Designed the Lead Detail Page to be consistent with the Contact Detail Page
- Added separate updates for:
  - Source
  - Notes
  - Preferred contact time

## Lead Detail Page

<img width="824" height="788" alt="image" src="https://github.com/user-attachments/assets/6f6eca72-3cd4-4ec1-a7b8-df26bb26742d" />


## Contact Detail Page

<img width="804" height="764" alt="image" src="https://github.com/user-attachments/assets/722e45f3-d7c2-4253-9571-5025ad4dec7d" />


## Notes

The Lead and Contact detail pages now have consistent layouts and independently editable fields for source, notes, and preferred contact time.

<img width="844" height="491" alt="image" src="https://github.com/user-attachments/assets/dcd5c56b-692d-4859-b4a8-43dfcf079e93" />
